### PR TITLE
Replace emoji with material icons and add email toast

### DIFF
--- a/src/components/sections/ChatSection.tsx
+++ b/src/components/sections/ChatSection.tsx
@@ -247,7 +247,7 @@ const ChatSection: React.FC = () => {
           <div className="glass-strong p-4 border-b flex justify-between items-center" style={{ borderColor: 'var(--glass-border)' }}>
             <div className="flex items-center space-x-3">
               <div className="glass rounded-full p-2">
-                <span className="text-xl">🤖</span>
+                <span className="material-icons text-xl">smart_toy</span>
               </div>
               <div>
                 <h3 className="font-semibold" style={{ color: 'var(--foreground)' }}>
@@ -272,7 +272,7 @@ const ChatSection: React.FC = () => {
                   style={{ color: 'var(--primary)' }}
                   title="Configure API Key"
                 >
-                  🔑 Setup
+                  <span className="material-icons align-middle mr-1">vpn_key</span> Setup
                 </button>
               )}
               {messages.length > 0 && (
@@ -282,7 +282,7 @@ const ChatSection: React.FC = () => {
                   style={{ color: 'var(--muted-foreground)' }}
                   title="Clear history"
                 >
-                  🗑️ Clear
+                  <span className="material-icons align-middle mr-1">delete</span> Clear
                 </button>
               )}  
             </div>
@@ -300,7 +300,7 @@ const ChatSection: React.FC = () => {
               {messages.length === 0 && (
                 <div className="flex items-start space-x-4 animate-fade-in-up">
                   <div className="glass rounded-full p-3 flex-shrink-0">
-                    <span className="text-2xl">🤖</span>
+                      <span className="material-icons text-2xl">smart_toy</span>
                   </div>
                   <div className="glass rounded-2xl p-4 max-w-2xl border-l-4" style={{ borderLeftColor: 'var(--primary)' }}>
                     <ReactMarkdown 
@@ -319,7 +319,7 @@ const ChatSection: React.FC = () => {
                     >
                       Hi! I'm ESSERTAIZE's AI assistant. Feel free to ask me questions about his projects, skills or experience!
                       
-                      💡 I now keep memory of our conversation.
+                        <span className="material-icons align-middle mr-1">lightbulb</span> I now keep memory of our conversation.
                     </ReactMarkdown>
                   </div>
                 </div>
@@ -332,7 +332,7 @@ const ChatSection: React.FC = () => {
                   className={`flex items-start space-x-4 ${msg.role === 'user' ? 'flex-row-reverse space-x-reverse' : ''}`}
                 >
                   <div className="glass rounded-full p-3 flex-shrink-0">
-                    <span className="text-2xl">{msg.role === 'user' ? '👤' : '🤖'}</span>
+                      <span className="material-icons text-2xl">{msg.role === 'user' ? 'person' : 'smart_toy'}</span>
                   </div>
                   <div 
                     className={`glass rounded-2xl p-4 max-w-4xl border-l-4 ${msg.role === 'user' ? 'border-r-4 border-l-0' : ''}`}
@@ -381,7 +381,7 @@ const ChatSection: React.FC = () => {
               {isLoading && (
                 <div className="flex items-start space-x-4">
                   <div className="glass rounded-full p-3 flex-shrink-0">
-                    <span className="text-2xl">🤖</span>
+                    <span className="material-icons text-2xl">smart_toy</span>
                   </div>
                   <div className="glass rounded-2xl p-4 border-l-4" style={{ borderLeftColor: 'var(--primary)' }}>
                     <div className="flex space-x-1">
@@ -449,7 +449,7 @@ const ChatSection: React.FC = () => {
         <div className="grid md:grid-cols-3 gap-6 mt-12">
           <div className="text-center card-glass rounded-2xl p-6 hover:scale-105 transition-all duration-300">
             <div className="w-16 h-16 mx-auto mb-4 rounded-2xl flex items-center justify-center glass-subtle">
-              <span className="text-3xl">🧠</span>
+              <span className="material-icons text-3xl">psychology</span>
             </div>
             <h3 className="font-semibold mb-3" style={{ color: 'var(--foreground)' }}>
               Contextual Memory
@@ -461,7 +461,7 @@ const ChatSection: React.FC = () => {
           
           <div className="text-center card-glass rounded-2xl p-6 hover:scale-105 transition-all duration-300">
             <div className="w-16 h-16 mx-auto mb-4 rounded-2xl flex items-center justify-center glass-subtle">
-              <span className="text-3xl">🔐</span>
+              <span className="material-icons text-3xl">lock</span>
             </div>
             <h3 className="font-semibold mb-3" style={{ color: 'var(--foreground)' }}>
               Local History
@@ -473,7 +473,7 @@ const ChatSection: React.FC = () => {
           
           <div className="text-center card-glass rounded-2xl p-6 hover:scale-105 transition-all duration-300">
             <div className="w-16 h-16 mx-auto mb-4 rounded-2xl flex items-center justify-center glass-subtle">
-              <span className="text-3xl">💬</span>
+              <span className="material-icons text-3xl">chat</span>
             </div>
             <h3 className="font-semibold mb-3" style={{ color: 'var(--foreground)' }}>
               Powered by DeepSeek

--- a/src/components/sections/ProjectSection.tsx
+++ b/src/components/sections/ProjectSection.tsx
@@ -11,6 +11,13 @@ const ProjectsSection: React.FC = () => {
     animationDelay: number;
     animationDuration: number;
   }>>([]);
+  const [showToast, setShowToast] = useState(false);
+
+  const copyEmail = () => {
+    navigator.clipboard.writeText('nolan.essertaize26@gmail.com');
+    setShowToast(true);
+    setTimeout(() => setShowToast(false), 3000);
+  };
 
   // Generate random values only on client-side
   useEffect(() => {
@@ -154,15 +161,15 @@ const ProjectsSection: React.FC = () => {
                   {/* Corner Badge for Featured Project */}
                   {project.featured && (
                     <div className="absolute top-4 right-4">
-                      <div 
+                      <div
                         className="glass-strong text-xs font-semibold px-3 py-1 rounded-full border transform rotate-12"
-                        style={{ 
+                        style={{
                           color: 'var(--primary)',
                           borderColor: 'var(--primary)',
                           backgroundColor: 'var(--glass-bg)'
                         }}
                       >
-                        ⭐ Featured
+                        <span className="material-icons align-middle mr-1">star</span> Featured
                       </div>
                     </div>
                   )}
@@ -259,12 +266,21 @@ const ProjectsSection: React.FC = () => {
             >
               I&apos;m always open to discussing new opportunities and exciting projects.
             </p>
-            <button 
+            <button
+              onClick={copyEmail}
               className="btn-glass px-6 py-3 rounded-xl font-medium transition-all duration-300"
               style={{ color: 'var(--primary)' }}
             >
-              Get In Touch
+              Keep in Touch
             </button>
+            {showToast && (
+              <div
+                className="fixed bottom-4 left-1/2 transform -translate-x-1/2 glass-strong px-4 py-2 rounded-xl"
+                style={{ color: 'var(--foreground)', backgroundColor: 'var(--glass-bg)' }}
+              >
+                Email copied!
+              </div>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- swap emoji for Material Icons across ChatSection
- use Material Icon star for project feature badge
- add email copy toast on "Keep in Touch" button

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dbdd382b8832eb766bf18888aa9aa