### PR TITLE
Move email toast to top

### DIFF
--- a/src/components/sections/ProjectSection.tsx
+++ b/src/components/sections/ProjectSection.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 const ProjectsSection: React.FC = () => {
   const [mounted, setMounted] = useState(false);
@@ -12,11 +12,32 @@ const ProjectsSection: React.FC = () => {
     animationDuration: number;
   }>>([]);
   const [showToast, setShowToast] = useState(false);
+  const [toastPosition, setToastPosition] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
+  const [toastOpacity, setToastOpacity] = useState(0);
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
   const copyEmail = () => {
     navigator.clipboard.writeText('nolan.essertaize26@gmail.com');
-    setShowToast(true);
-    setTimeout(() => setShowToast(false), 3000);
+    if (buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect();
+      const startTop = rect.top + rect.height / 2;
+      const startLeft = rect.left + rect.width / 2;
+      setToastPosition({ top: startTop, left: startLeft });
+      setToastOpacity(1);
+      setShowToast(true);
+      requestAnimationFrame(() => {
+        setToastPosition({ top: 16, left: window.innerWidth / 2 });
+      });
+      setTimeout(() => {
+        const returnRect = buttonRef.current!.getBoundingClientRect();
+        setToastPosition({
+          top: returnRect.top + returnRect.height / 2,
+          left: returnRect.left + returnRect.width / 2,
+        });
+        setToastOpacity(0);
+      }, 2500);
+      setTimeout(() => setShowToast(false), 3000);
+    }
   };
 
   // Generate random values only on client-side
@@ -268,6 +289,7 @@ const ProjectsSection: React.FC = () => {
             </p>
             <button
               onClick={copyEmail}
+              ref={buttonRef}
               className="btn-glass px-6 py-3 rounded-xl font-medium transition-all duration-300"
               style={{ color: 'var(--primary)' }}
             >
@@ -275,8 +297,15 @@ const ProjectsSection: React.FC = () => {
             </button>
             {showToast && (
               <div
-                className="fixed bottom-4 left-1/2 transform -translate-x-1/2 glass-strong px-4 py-2 rounded-xl"
-                style={{ color: 'var(--foreground)', backgroundColor: 'var(--glass-bg)' }}
+                className="fixed glass-strong px-4 py-2 rounded-xl z-50 transition-[top,left,opacity] duration-500"
+                style={{
+                  color: 'var(--foreground)',
+                  backgroundColor: 'var(--glass-bg)',
+                  top: toastPosition.top,
+                  left: toastPosition.left,
+                  opacity: toastOpacity,
+                  transform: 'translate(-50%, -50%)',
+                }}
               >
                 Email copied!
               </div>


### PR DESCRIPTION
## Summary
- position the mail toast at the top of the page
- animate the toast from the button to the header

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dc176a548832eb103501ced0d9469