### PR TITLE
Fix toast animation and consolidate glass styles

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -118,6 +118,19 @@ body {
   box-shadow: 0 4px 20px var(--glass-shadow);
 }
 
+/* Shorthand utility classes used throughout the components */
+.glass {
+  @apply glass-effect;
+}
+
+.glass-subtle {
+  @apply glass-effect-subtle;
+}
+
+.glass-strong {
+  @apply glass-effect-strong;
+}
+
 @keyframes fade-in-up {
   from {
     opacity: 0;
@@ -217,11 +230,7 @@ html {
 }
 
 .btn-glass {
-  background: var(--glass-bg);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  border: 1px solid var(--glass-border);
-  box-shadow: 0 8px 32px var(--glass-shadow);
+  @apply glass;
   transition: all 0.3s ease;
 }
 
@@ -232,11 +241,7 @@ html {
 }
 
 .card-glass {
-  background: var(--surface-glass);
-  backdrop-filter: blur(15px);
-  -webkit-backdrop-filter: blur(15px);
-  border: 1px solid var(--glass-border);
-  box-shadow: 0 12px 40px var(--glass-shadow);
+  @apply glass-strong;
   transition: all 0.3s ease;
 }
 
@@ -254,6 +259,9 @@ html {
   .glass-effect,
   .glass-effect-strong,
   .glass-effect-subtle,
+  .glass,
+  .glass-strong,
+  .glass-subtle,
   .btn-glass,
   .card-glass {
     -webkit-backdrop-filter: blur(15px);
@@ -268,7 +276,11 @@ img {
 .animate-float,
 .animate-fade-in-up,
 .glass-effect,
-.card-glass {
+.card-glass,
+.glass,
+.glass-strong,
+.glass-subtle,
+.btn-glass {
   will-change: transform;
   transform-style: preserve-3d;
   backface-visibility: hidden;

--- a/src/components/sections/ProjectSection.tsx
+++ b/src/components/sections/ProjectSection.tsx
@@ -25,8 +25,11 @@ const ProjectsSection: React.FC = () => {
       setToastPosition({ top: startTop, left: startLeft });
       setToastOpacity(1);
       setShowToast(true);
+      // Wait for the toast to be rendered before starting the animation
       requestAnimationFrame(() => {
-        setToastPosition({ top: 16, left: window.innerWidth / 2 });
+        requestAnimationFrame(() => {
+          setToastPosition({ top: 16, left: window.innerWidth / 2 });
+        });
       });
       setTimeout(() => {
         const returnRect = buttonRef.current!.getBoundingClientRect();
@@ -297,7 +300,7 @@ const ProjectsSection: React.FC = () => {
             </button>
             {showToast && (
               <div
-                className="fixed glass-strong px-4 py-2 rounded-xl z-50 transition-[top,left,opacity] duration-500"
+                className="fixed glass-strong px-4 py-2 rounded-xl z-50 transition-[top,left,opacity,transform] duration-500"
                 style={{
                   color: 'var(--foreground)',
                   backgroundColor: 'var(--glass-bg)',


### PR DESCRIPTION
## Summary
- define reusable glass classes and refactor existing styles
- use new utilities for button and card glass effects
- ensure webkit support for new classes
- apply will-change optimisations to all glass elements
- fix toast animation in projects section with double `requestAnimationFrame`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dc82f8d70832ea83551d9cb5a7d38