### PR TITLE
Fix streaming mode for chat

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -2,6 +2,9 @@ import { streamText } from 'ai'
 import { createGoogleGenerativeAI } from '@ai-sdk/google'
 import { NextResponse } from 'next/server'
 
+export const runtime = 'edge'
+export const dynamic = 'force-dynamic'
+
 interface ChatMessage {
     role: 'user' | 'assistant' | 'system'
     content: string

--- a/src/components/sections/ChatSection.tsx
+++ b/src/components/sections/ChatSection.tsx
@@ -23,6 +23,7 @@ const ChatSection: React.FC = () => {
         body: {
             apiKey: serverHasApiKey ? undefined : apiKey,
         },
+        streamMode: 'sse',
         onResponse: (response) => {
             if (response.status === 401) {
                 setShowApiKeyInput(true)


### PR DESCRIPTION
## Summary
- enable edge runtime to allow streamed responses
- configure ChatSection to use SSE streaming mode

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68737b176534832e9b4ec016a90a280d