### PR TITLE
Fix streaming mode for chat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Example environment configuration
+# Copy to .env.local and fill in your values
+
+# Optional DeepSeek API key (unused currently)
+DEEPSEEK_API_KEY=
+
+# Next.js configuration
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+# Google Gemini API key used by the chat API (server only)
+GOOGLE_API_KEY=

--- a/.env.local
+++ b/.env.local
@@ -1,6 +1,6 @@
 # DeepSeek API Key 
-DEEPSEEK_API_KEY=sk-fdd58e63609643f88d0e466870e6bd5d
+DEEPSEEK_API_KEY=
 
 # Configuration Next.js
 NEXT_PUBLIC_APP_URL=http://localhost:3000
-GOOGLE_API_KEY=your_google_key
+GOOGLE_API_KEY=

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,8 +31,10 @@ jobs:
    
   deploy:
       runs-on: self-hosted
-      needs: build-push   
-      environment: portfolio 
+      needs: build-push
+      environment: portfolio
+      env:
+        GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
       steps:
         - name: SSH Deploy to Tailscale server
           uses: appleboy/ssh-action@v0.1.7
@@ -40,8 +42,9 @@ jobs:
             host: nolanserver
             username: sr13
             key: ${{ secrets.SERVER_SSH_KEY }}
+            envs: GOOGLE_API_KEY
             script: |
               docker pull nolansr13/essertaize-portfolio
               docker stop essertaize-portfolio || true
               docker rm essertaize-portfolio || true
-              docker run -d --name essertaize-portfolio -p 3000:3000 nolansr13/essertaize-portfolio:latest
+              docker run -d --name essertaize-portfolio -p 3000:3000 -e GOOGLE_API_KEY="$GOOGLE_API_KEY" nolansr13/essertaize-portfolio:latest

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ pnpm dev
 bun dev
 ```
 
+### Environment variables
+
+Create a `.env.local` file based on `.env.example` and provide your `GOOGLE_API_KEY`. This value is kept server-side and is not exposed in the client bundle.
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -2,6 +2,9 @@ import { streamText } from 'ai'
 import { createGoogleGenerativeAI } from '@ai-sdk/google'
 import { NextResponse } from 'next/server'
 
+export const runtime = 'edge'
+export const dynamic = 'force-dynamic'
+
 interface ChatMessage {
     role: 'user' | 'assistant' | 'system'
     content: string

--- a/src/components/sections/ChatSection.tsx
+++ b/src/components/sections/ChatSection.tsx
@@ -23,6 +23,7 @@ const ChatSection: React.FC = () => {
         body: {
             apiKey: serverHasApiKey ? undefined : apiKey,
         },
+        streamMode: 'sse',
         onResponse: (response) => {
             if (response.status === 401) {
                 setShowApiKeyInput(true)


### PR DESCRIPTION
## Summary
- enable edge runtime to allow streamed responses
- configure ChatSection to use SSE streaming mode
- store API key using environment variables
- add example env file and document setup
- pass Google API key as secret in workflow

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68737b176534832e9b4ec016a90a280d