### PR TITLE
Add Kaizen Learning demo page with mock lesson API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
                 "next": "15.3.3",
                 "react": "^19.0.0",
                 "react-dom": "^19.0.0",
-                "react-markdown": "^10.1.0"
+                "react-markdown": "^10.1.0",
+                "zod": "^3.25.67"
             },
             "devDependencies": {
                 "@eslint/eslintrc": "^3",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-markdown": "^10.1.0"
+        "react-markdown": "^10.1.0",
+        "zod": "^3.25.67"
     },
     "devDependencies": {
         "@eslint/eslintrc": "^3",

--- a/src/app/api/lesson/route.ts
+++ b/src/app/api/lesson/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server';
+import type { LessonSchema } from '@/lib/lessonSchema';
+
+export async function POST(req: Request) {
+  const { topic, level } = (await req.json()) as { topic: LessonSchema['topic']; level: LessonSchema['level']; };
+
+  // simulate delay between 1.5-2s
+  const delay = 1500 + Math.random() * 500;
+  await new Promise((res) => setTimeout(res, delay));
+
+  // 5% chance of invalid JSON
+  if (Math.random() < 0.05) {
+    const invalid: Omit<LessonSchema, 'exercise'> & {
+      exercise: Omit<LessonSchema['exercise'], 'answer_index'>
+    } = {
+      title: `${level} ${topic} Lesson`,
+      duration_min: 10,
+      topic,
+      level,
+      lesson: [{ type: 'text', content: `Intro to ${topic}.` }],
+      example: [{ type: 'text', content: `Example about ${topic}.` }],
+      exercise: {
+        question: `Sample question on ${topic}?`,
+        type: 'single_choice',
+        choices: ['Option A', 'Option B', 'Option C'],
+        explain_correct: 'Good job!',
+        explain_incorrect: 'Not quite.'
+      }
+    };
+    return NextResponse.json(invalid);
+  }
+
+  const lesson: LessonSchema = {
+    title: `${level} ${topic} Basics`,
+    duration_min: 10,
+    topic,
+    level,
+    lesson: [
+      { type: 'text', content: `Welcome to ${topic}. This is a ${level.toLowerCase()} introduction.` },
+      { type: 'code', lang: 'text', content: `Code or formula snippet for ${topic}.` }
+    ],
+    example: [
+      { type: 'text', content: `Here's an example related to ${topic}.` }
+    ],
+    exercise: {
+      question: `What is 2 + 2?`,
+      type: 'single_choice',
+      choices: ['3', '4', '5'],
+      answer_index: 1,
+      explain_correct: '4 is the correct answer.',
+      explain_incorrect: 'Incorrect. The right answer is 4.'
+    }
+  };
+
+  return NextResponse.json(lesson);
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -289,3 +289,14 @@ img {
         scroll-behavior: auto;
     }
 }
+
+@keyframes breathe {
+  0%, 100% {
+    transform: scale(0.98);
+    opacity: 0.8;
+  }
+  50% {
+    transform: scale(1.02);
+    opacity: 1;
+  }
+}

--- a/src/app/kaizen/page.tsx
+++ b/src/app/kaizen/page.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useState } from 'react';
+import { lessonSchema, type LessonSchema, type LessonBlock } from '@/lib/lessonSchema';
+
+export default function KaizenPage() {
+  type Topic = LessonSchema['topic'];
+  type Level = LessonSchema['level'];
+  const topics: Topic[] = ['Math', 'Physics', 'English', 'IT', 'Mechanics'];
+  const levels: Level[] = ['Easy', 'Medium', 'Hard'];
+
+  const [topic, setTopic] = useState<Topic>('Math');
+  const [level, setLevel] = useState<Level>('Easy');
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+  const [lesson, setLesson] = useState<LessonSchema | null>(null);
+  const [selectedChoice, setSelectedChoice] = useState<number | null>(null);
+  const [grade, setGrade] = useState<'correct' | 'incorrect' | null>(null);
+
+  const handleGenerate = async () => {
+    setStatus('loading');
+    setLesson(null);
+    setSelectedChoice(null);
+    setGrade(null);
+    try {
+      const res = await fetch('/api/lesson', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ topic, level }),
+      });
+      const data = await res.json();
+      const parsed = lessonSchema.safeParse(data);
+      if (!parsed.success) throw new Error('Invalid');
+      setLesson(parsed.data);
+      setStatus('success');
+    } catch (e) {
+      console.error(e);
+      setStatus('error');
+    }
+  };
+
+  const handleCheckAnswer = () => {
+    if (lesson && selectedChoice !== null) {
+      setGrade(selectedChoice === lesson.exercise.answer_index ? 'correct' : 'incorrect');
+    }
+  };
+
+  const renderBlock = (block: LessonBlock, idx: number) => {
+    if (block.type === 'text') {
+      return <p key={idx} className="mb-2">{block.content}</p>;
+    }
+    return (
+      <pre key={idx} className="mb-2 p-2 bg-gray-100 rounded overflow-x-auto"><code>{block.content}</code></pre>
+    );
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center">
+      <header className="w-full flex justify-between items-center p-4 border-b">
+        <h1 className="text-lg font-semibold">Kaizen Learning (Demo)</h1>
+        <button className="text-gray-500 cursor-not-allowed">Login</button>
+      </header>
+      <main className="w-full flex justify-center p-4">
+        <div className="w-full max-w-2xl bg-white rounded-xl shadow p-6">
+          <div className="flex flex-wrap gap-4 mb-6">
+            <div className="flex flex-col flex-1 min-w-[150px]">
+              <label htmlFor="topic" className="font-medium">Topic</label>
+              <select
+                id="topic"
+                className="mt-1 p-2 border rounded"
+                value={topic}
+                onChange={(e) => setTopic(e.target.value as Topic)}
+              >
+                {topics.map((t) => (
+                  <option key={t} value={t}>{t}</option>
+                ))}
+              </select>
+            </div>
+            <div className="flex flex-col flex-1 min-w-[150px]">
+              <label htmlFor="level" className="font-medium">Level</label>
+              <select
+                id="level"
+                className="mt-1 p-2 border rounded"
+                value={level}
+                onChange={(e) => setLevel(e.target.value as Level)}
+              >
+                {levels.map((l) => (
+                  <option key={l} value={l}>{l}</option>
+                ))}
+              </select>
+            </div>
+            <button
+              onClick={handleGenerate}
+              disabled={status === 'loading'}
+              className="self-end px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+            >
+              Generate Lesson
+            </button>
+          </div>
+
+          {status === 'error' && (
+            <div className="p-3 mb-4 rounded bg-red-100 text-red-800 flex items-center justify-between">
+              <span>Couldn&apos;t generate a valid lesson. Try again.</span>
+              <button onClick={handleGenerate} className="ml-4 px-3 py-1 border rounded">
+                Retry
+              </button>
+            </div>
+          )}
+
+          {status === 'success' && lesson && (
+            <div>
+              <h2 className="text-xl font-semibold mb-2">{lesson.title}</h2>
+              <p className="text-sm text-gray-600 mb-4">{lesson.topic} • {lesson.level} • {lesson.duration_min} min</p>
+              <div className="mb-4">
+                {lesson.lesson.map(renderBlock)}
+              </div>
+              <div className="mb-4">
+                <h3 className="font-semibold mb-2">Example</h3>
+                {lesson.example.map(renderBlock)}
+              </div>
+              <div>
+                <h3 className="font-semibold mb-2">Exercise</h3>
+                <p className="mb-2">{lesson.exercise.question}</p>
+                <div className="space-y-2">
+                  {lesson.exercise.choices.map((choice, idx) => (
+                    <label key={idx} className="flex items-center gap-2">
+                      <input
+                        type="radio"
+                        name="exercise"
+                        value={idx}
+                        checked={selectedChoice === idx}
+                        onChange={() => setSelectedChoice(idx)}
+                      />
+                      <span>{choice}</span>
+                    </label>
+                  ))}
+                </div>
+                <button
+                  onClick={handleCheckAnswer}
+                  disabled={selectedChoice === null}
+                  className="mt-4 px-4 py-2 bg-green-600 text-white rounded disabled:opacity-50"
+                >
+                  Check Answer
+                </button>
+                <div className="mt-4" aria-live="polite">
+                  {grade === 'correct' && (
+                    <div className="p-3 rounded bg-green-100 text-green-800">{lesson.exercise.explain_correct}</div>
+                  )}
+                  {grade === 'incorrect' && (
+                    <div className="p-3 rounded bg-red-100 text-red-800">{lesson.exercise.explain_incorrect}</div>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </main>
+
+      {status === 'loading' && (
+        <div className="fixed inset-0 flex flex-col items-center justify-center backdrop-blur-sm bg-gradient-to-br from-gray-700/40 to-gray-900/40">
+          <div className="w-16 h-16 bg-blue-600 rounded-full animate-breathe" />
+          <p className="mt-4 text-white">Generating your lesson…</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/lessonSchema.ts
+++ b/src/lib/lessonSchema.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+export const lessonBlockSchema = z.union([
+  z.object({ type: z.literal('text'), content: z.string() }),
+  z.object({ type: z.literal('code'), lang: z.string().optional(), content: z.string() })
+]);
+
+export const lessonSchema = z.object({
+  title: z.string(),
+  duration_min: z.number().int().min(5).max(15),
+  topic: z.enum(['Math', 'Physics', 'English', 'IT', 'Mechanics']),
+  level: z.enum(['Easy', 'Medium', 'Hard']),
+  lesson: z.array(lessonBlockSchema).min(2).max(6),
+  example: z.array(lessonBlockSchema).min(1).max(3),
+  exercise: z.object({
+    question: z.string(),
+    type: z.literal('single_choice'),
+    choices: z.array(z.string()).min(3).max(6),
+    answer_index: z.number().int(),
+    explain_correct: z.string(),
+    explain_incorrect: z.string()
+  })
+});
+
+export type LessonSchema = z.infer<typeof lessonSchema>;
+export type LessonBlock = LessonSchema['lesson'][number];

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,17 @@ module.exports = {
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      keyframes: {
+        breathe: {
+          '0%,100%': { transform: 'scale(0.98)', opacity: '0.8' },
+          '50%': { transform: 'scale(1.02)', opacity: '1' },
+        },
+      },
+      animation: {
+        breathe: 'breathe 2.4s ease-in-out infinite',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- add Zod-based `LessonSchema` type
- create `/api/lesson` mock endpoint returning schema-compliant lessons with 5% invalid responses
- build `Kaizen Learning` demo page with topic/level selectors, loading overlay, lesson rendering, and exercise grading
- add breathing animation utilities in Tailwind config and globals

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ce268c6f0832e946501d966fba5ee