### PR TITLE
feat: add kaizen lesson demo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
                 "next": "15.3.3",
                 "react": "^19.0.0",
                 "react-dom": "^19.0.0",
-                "react-markdown": "^10.1.0"
+                "react-markdown": "^10.1.0",
+                "zod": "^3.25.0"
             },
             "devDependencies": {
                 "@eslint/eslintrc": "^3",
@@ -7660,7 +7661,6 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
             "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-markdown": "^10.1.0"
+        "react-markdown": "^10.1.0",
+        "zod": "^3.25.0"
     },
     "devDependencies": {
         "@eslint/eslintrc": "^3",

--- a/src/app/api/lesson/route.ts
+++ b/src/app/api/lesson/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { Lesson } from '@/lib/lessonSchema';
+
+type Topic = 'Math' | 'Physics' | 'English' | 'IT' | 'Mechanics';
+type Level = 'Easy' | 'Medium' | 'Hard';
+
+function generateLesson(topic: Topic, level: Level): Lesson {
+  const hash = (topic.length + level.length) % 3;
+  const duration = 5 + ((topic.length + level.length) % 11);
+  return {
+    title: `${topic} ${level} Lesson`,
+    duration_min: duration,
+    topic,
+    level,
+    lesson: [
+      { type: 'text', content: `This lesson covers ${topic} at ${level} level.` },
+      { type: 'code', lang: 'ts', content: `// ${topic} example\nconsole.log('${topic}');` },
+    ],
+    example: [
+      { type: 'text', content: `Consider this example for ${topic}.` },
+    ],
+    exercise: {
+      question: `Sample question about ${topic}?`,
+      type: 'single_choice',
+      choices: ['Option A', 'Option B', 'Option C'],
+      answer_index: hash,
+      explain_correct: 'Correct answer!',
+      explain_incorrect: 'Incorrect answer.',
+    },
+  };
+}
+
+export async function POST(req: Request) {
+  const { topic, level }: { topic: Topic; level: Level } = await req.json();
+  await new Promise((res) => setTimeout(res, 1700));
+  const lesson = generateLesson(topic, level);
+  if (Math.random() < 0.05) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const invalid: any = { ...lesson };
+    delete invalid.exercise.answer_index;
+    return NextResponse.json(invalid);
+  }
+  return NextResponse.json(lesson);
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -159,6 +159,18 @@ body {
     }
 }
 
+@keyframes breathe {
+    0%,
+    100% {
+        transform: scale(0.98);
+        opacity: 0.8;
+    }
+    50% {
+        transform: scale(1.02);
+        opacity: 1;
+    }
+}
+
 .animate-fade-in-up {
     animation: fade-in-up 0.8s ease-out forwards;
 }
@@ -173,6 +185,10 @@ body {
 
 .animate-mountain-glow {
     animation: mountain-glow 4s ease-in-out infinite;
+}
+
+.animate-breathe {
+    animation: breathe 2.4s ease-in-out infinite;
 }
 
 .animation-delay-300 {

--- a/src/app/kaizen/page.tsx
+++ b/src/app/kaizen/page.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import { useState } from 'react';
+import BreathingLoader from '@/components/kaizen/BreathingLoader';
+import { lessonSchema, Lesson } from '@/lib/lessonSchema';
+
+const topics = ['Math', 'Physics', 'English', 'IT', 'Mechanics'] as const;
+const levels = ['Easy', 'Medium', 'Hard'] as const;
+
+type Topic = (typeof topics)[number];
+type Level = (typeof levels)[number];
+
+enum Status {
+  Idle = 'idle',
+  Loading = 'loading',
+  Success = 'success',
+  Error = 'error',
+}
+
+export default function KaizenPage() {
+  const [topic, setTopic] = useState<Topic>('Math');
+  const [level, setLevel] = useState<Level>('Easy');
+  const [status, setStatus] = useState<Status>(Status.Idle);
+  const [lesson, setLesson] = useState<Lesson | null>(null);
+  const [selected, setSelected] = useState<number | null>(null);
+  const [grade, setGrade] = useState<'correct' | 'incorrect' | null>(null);
+
+  const handleGenerate = async () => {
+    setStatus(Status.Loading);
+    setLesson(null);
+    setSelected(null);
+    setGrade(null);
+    try {
+      const res = await fetch('/api/lesson', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ topic, level }),
+      });
+      const data = await res.json();
+      const parsed = lessonSchema.safeParse(data);
+      if (parsed.success) {
+        setLesson(parsed.data);
+        setStatus(Status.Success);
+      } else {
+        setStatus(Status.Error);
+      }
+    } catch {
+      setStatus(Status.Error);
+    }
+  };
+
+  const handleCheck = () => {
+    if (!lesson || selected === null) return;
+    if (selected === lesson.exercise.answer_index) {
+      setGrade('correct');
+    } else {
+      setGrade('incorrect');
+    }
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-16 space-y-8">
+      <h1 className="text-3xl font-bold text-[var(--foreground)]">Kaizen Demo</h1>
+
+      <div className="space-y-4">
+        <div className="flex flex-col sm:flex-row sm:space-x-4 space-y-4 sm:space-y-0">
+          <div className="flex-1">
+            <label className="block mb-2 text-sm font-medium text-[var(--foreground)]">Topic</label>
+            <select
+              className="w-full glass px-4 py-2 rounded-xl bg-[var(--surface)] text-[var(--foreground)] disabled:opacity-50"
+              value={topic}
+              onChange={(e) => setTopic(e.target.value as Topic)}
+              disabled={status === Status.Loading}
+            >
+              {topics.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex-1">
+            <label className="block mb-2 text-sm font-medium text-[var(--foreground)]">Level</label>
+            <select
+              className="w-full glass px-4 py-2 rounded-xl bg-[var(--surface)] text-[var(--foreground)] disabled:opacity-50"
+              value={level}
+              onChange={(e) => setLevel(e.target.value as Level)}
+              disabled={status === Status.Loading}
+            >
+              {levels.map((l) => (
+                <option key={l} value={l}>
+                  {l}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+        <button
+          onClick={handleGenerate}
+          className="btn-glass px-6 py-3 rounded-xl font-medium text-[var(--primary)] disabled:opacity-50"
+          disabled={status === Status.Loading}
+        >
+          Generate Lesson
+        </button>
+      </div>
+
+      {status === Status.Error && (
+        <div className="card-glass rounded-xl p-4 text-[var(--primary)] space-y-4">
+          <p>Something went wrong. Please try again.</p>
+          <button
+            onClick={handleGenerate}
+            className="btn-glass px-4 py-2 rounded-lg text-[var(--primary)]"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {status === Status.Success && lesson && (
+        <div className="space-y-8">
+          <header className="card-glass p-6 rounded-xl space-y-2">
+            <h2 className="text-2xl font-bold text-[var(--foreground)]">{lesson.title}</h2>
+            <p className="text-sm text-[var(--muted-foreground)]">
+              {lesson.topic} • {lesson.level} • {lesson.duration_min} min
+            </p>
+          </header>
+
+          <section className="space-y-4">
+            <h3 className="text-xl font-semibold text-[var(--foreground)]">Lesson</h3>
+            {lesson.lesson.map((block, i) =>
+              block.type === 'text' ? (
+                <p key={i} className="text-[var(--foreground)]">
+                  {block.content}
+                </p>
+              ) : (
+                <pre
+                  key={i}
+                  className="card-glass p-4 rounded-xl overflow-auto text-sm font-mono text-[var(--foreground)]"
+                >
+                  <code>{block.content}</code>
+                </pre>
+              ),
+            )}
+          </section>
+
+          <section className="space-y-4">
+            <h3 className="text-xl font-semibold text-[var(--foreground)]">Example</h3>
+            {lesson.example.map((block, i) =>
+              block.type === 'text' ? (
+                <p key={i} className="text-[var(--foreground)]">
+                  {block.content}
+                </p>
+              ) : (
+                <pre
+                  key={i}
+                  className="card-glass p-4 rounded-xl overflow-auto text-sm font-mono text-[var(--foreground)]"
+                >
+                  <code>{block.content}</code>
+                </pre>
+              ),
+            )}
+          </section>
+
+          <section className="space-y-4">
+            <h3 className="text-xl font-semibold text-[var(--foreground)]">Exercise</h3>
+            <p className="text-[var(--foreground)]">{lesson.exercise.question}</p>
+            <div className="space-y-2">
+              {lesson.exercise.choices.map((choice, i) => (
+                <label key={i} className="flex items-center space-x-2">
+                  <input
+                    type="radio"
+                    className="accent-[var(--primary)]"
+                    name="exercise"
+                    value={i}
+                    checked={selected === i}
+                    onChange={() => setSelected(i)}
+                  />
+                  <span className="text-[var(--foreground)]">{choice}</span>
+                </label>
+              ))}
+            </div>
+            <button
+              onClick={handleCheck}
+              className="btn-glass px-4 py-2 rounded-xl text-[var(--primary)] disabled:opacity-50"
+              disabled={selected === null}
+            >
+              Check Answer
+            </button>
+            <div aria-live="polite">
+              {grade === 'correct' && (
+                <div className="card-glass mt-4 p-4 rounded-xl text-[var(--foreground)]">
+                  <p className="font-semibold text-[var(--secondary-foreground)]">Correct!</p>
+                  <p className="text-sm text-[var(--muted-foreground)]">
+                    {lesson.exercise.explain_correct}
+                  </p>
+                </div>
+              )}
+              {grade === 'incorrect' && (
+                <div className="card-glass mt-4 p-4 rounded-xl text-[var(--foreground)]">
+                  <p className="font-semibold text-[var(--primary-foreground)]">Incorrect.</p>
+                  <p className="text-sm text-[var(--muted-foreground)]">
+                    {lesson.exercise.explain_incorrect}
+                  </p>
+                </div>
+              )}
+            </div>
+          </section>
+        </div>
+      )}
+
+      {status === Status.Loading && (
+        <div className="fixed inset-0 flex items-center justify-center bg-[var(--surface-glass)] backdrop-blur-md">
+          <BreathingLoader />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/kaizen/BreathingLoader.tsx
+++ b/src/components/kaizen/BreathingLoader.tsx
@@ -1,0 +1,5 @@
+export default function BreathingLoader() {
+  return (
+    <div className="w-12 h-12 rounded-full bg-[var(--primary)] animate-breathe"></div>
+  );
+}

--- a/src/lib/lessonSchema.ts
+++ b/src/lib/lessonSchema.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+export const lessonBlockSchema = z.union([
+  z.object({ type: z.literal('text'), content: z.string() }),
+  z.object({ type: z.literal('code'), content: z.string(), lang: z.string().optional() }),
+]);
+
+export const lessonSchema = z.object({
+  title: z.string(),
+  duration_min: z.number().min(5).max(15),
+  topic: z.enum(['Math', 'Physics', 'English', 'IT', 'Mechanics']),
+  level: z.enum(['Easy', 'Medium', 'Hard']),
+  lesson: z.array(lessonBlockSchema).min(2).max(6),
+  example: z.array(lessonBlockSchema).min(1).max(3),
+  exercise: z.object({
+    question: z.string(),
+    type: z.literal('single_choice'),
+    choices: z.array(z.string()).min(3).max(6),
+    answer_index: z.number(),
+    explain_correct: z.string(),
+    explain_incorrect: z.string(),
+  }),
+});
+
+export type Lesson = z.infer<typeof lessonSchema>;
+export type LessonBlock = z.infer<typeof lessonBlockSchema>;


### PR DESCRIPTION
## Summary
- add Zod schema for lessons
- mock API endpoint with deterministic lessons and occasional invalid payloads
- create Kaizen demo page with loading overlay, lesson rendering, and local exercise grading

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ce6050bd4832e88021180798f6412