### PR TITLE
Add Kaizen demo lesson page with mock API

### DIFF
--- a/src/app/api/lesson/route.ts
+++ b/src/app/api/lesson/route.ts
@@ -1,17 +1,22 @@
 import { NextResponse } from 'next/server';
 import type { LessonSchema } from '@/lib/lessonSchema';
 
+function shouldReturnInvalid(topic: LessonSchema['topic'], level: LessonSchema['level']) {
+  const key = (topic + level).split('').reduce((acc, c) => acc + c.charCodeAt(0), 0);
+  return key % 20 === 0;
+}
+
 export async function POST(req: Request) {
-  const { topic, level } = (await req.json()) as { topic: LessonSchema['topic']; level: LessonSchema['level']; };
+  const { topic, level } = (await req.json()) as {
+    topic: LessonSchema['topic'];
+    level: LessonSchema['level'];
+  };
 
-  // simulate delay between 1.5-2s
-  const delay = 1500 + Math.random() * 500;
-  await new Promise((res) => setTimeout(res, delay));
+  await new Promise((res) => setTimeout(res, 1700));
 
-  // 5% chance of invalid JSON
-  if (Math.random() < 0.05) {
+  if (shouldReturnInvalid(topic, level)) {
     const invalid: Omit<LessonSchema, 'exercise'> & {
-      exercise: Omit<LessonSchema['exercise'], 'answer_index'>
+      exercise: Omit<LessonSchema['exercise'], 'answer_index'>;
     } = {
       title: `${level} ${topic} Lesson`,
       duration_min: 10,
@@ -24,8 +29,8 @@ export async function POST(req: Request) {
         type: 'single_choice',
         choices: ['Option A', 'Option B', 'Option C'],
         explain_correct: 'Good job!',
-        explain_incorrect: 'Not quite.'
-      }
+        explain_incorrect: 'Not quite.',
+      },
     };
     return NextResponse.json(invalid);
   }
@@ -36,20 +41,21 @@ export async function POST(req: Request) {
     topic,
     level,
     lesson: [
-      { type: 'text', content: `Welcome to ${topic}. This is a ${level.toLowerCase()} introduction.` },
-      { type: 'code', lang: 'text', content: `Code or formula snippet for ${topic}.` }
+      {
+        type: 'text',
+        content: `Welcome to ${topic}. This is a ${level.toLowerCase()} introduction.`,
+      },
+      { type: 'code', lang: 'text', content: `Code or formula snippet for ${topic}.` },
     ],
-    example: [
-      { type: 'text', content: `Here's an example related to ${topic}.` }
-    ],
+    example: [{ type: 'text', content: `Here's an example related to ${topic}.` }],
     exercise: {
       question: `What is 2 + 2?`,
       type: 'single_choice',
       choices: ['3', '4', '5'],
       answer_index: 1,
       explain_correct: '4 is the correct answer.',
-      explain_incorrect: 'Incorrect. The right answer is 4.'
-    }
+      explain_incorrect: 'Incorrect. The right answer is 4.',
+    },
   };
 
   return NextResponse.json(lesson);

--- a/src/app/kaizen/page.tsx
+++ b/src/app/kaizen/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import BreathingLoader from '@/components/kaizen/BreathingLoader';
 import { lessonSchema, type LessonSchema, type LessonBlock } from '@/lib/lessonSchema';
 
 export default function KaizenPage() {
@@ -32,8 +33,7 @@ export default function KaizenPage() {
       if (!parsed.success) throw new Error('Invalid');
       setLesson(parsed.data);
       setStatus('success');
-    } catch (e) {
-      console.error(e);
+    } catch {
       setStatus('error');
     }
   };
@@ -49,116 +49,132 @@ export default function KaizenPage() {
       return <p key={idx} className="mb-2">{block.content}</p>;
     }
     return (
-      <pre key={idx} className="mb-2 p-2 bg-gray-100 rounded overflow-x-auto"><code>{block.content}</code></pre>
+      <pre
+        key={idx}
+        className="card-glass rounded-xl p-4 mb-2 overflow-x-auto font-mono text-sm"
+      >
+        <code>{block.content}</code>
+      </pre>
     );
   };
 
   return (
-    <div className="min-h-screen flex flex-col items-center">
-      <header className="w-full flex justify-between items-center p-4 border-b">
-        <h1 className="text-lg font-semibold">Kaizen Learning (Demo)</h1>
-        <button className="text-gray-500 cursor-not-allowed">Login</button>
+    <div className="min-h-screen flex flex-col">
+      <header className="glass-effect">
+        <div className="max-w-4xl mx-auto flex justify-between items-center p-4">
+          <h1 className="text-lg font-semibold">Kaizen Learning (Demo)</h1>
+          <button className="btn-glass px-4 py-2 rounded-xl cursor-not-allowed" disabled>Login</button>
+        </div>
       </header>
-      <main className="w-full flex justify-center p-4">
-        <div className="w-full max-w-2xl bg-white rounded-xl shadow p-6">
-          <div className="flex flex-wrap gap-4 mb-6">
-            <div className="flex flex-col flex-1 min-w-[150px]">
-              <label htmlFor="topic" className="font-medium">Topic</label>
-              <select
-                id="topic"
-                className="mt-1 p-2 border rounded"
-                value={topic}
-                onChange={(e) => setTopic(e.target.value as Topic)}
+      <main className="flex-1 w-full">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 py-8">
+          <div className="card-glass rounded-3xl p-6">
+            <div className="flex flex-wrap gap-4 mb-6">
+              <div className="flex flex-col flex-1 min-w-[150px]">
+                <label htmlFor="topic" className="mb-1">Topic</label>
+                <select
+                  id="topic"
+                  className="glass-effect rounded-xl p-2"
+                  value={topic}
+                  onChange={(e) => setTopic(e.target.value as Topic)}
+                  disabled={status === 'loading'}
+                >
+                  {topics.map((t) => (
+                    <option key={t} value={t}>{t}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="flex flex-col flex-1 min-w-[150px]">
+                <label htmlFor="level" className="mb-1">Level</label>
+                <select
+                  id="level"
+                  className="glass-effect rounded-xl p-2"
+                  value={level}
+                  onChange={(e) => setLevel(e.target.value as Level)}
+                  disabled={status === 'loading'}
+                >
+                  {levels.map((l) => (
+                    <option key={l} value={l}>{l}</option>
+                  ))}
+                </select>
+              </div>
+              <button
+                onClick={handleGenerate}
+                disabled={status === 'loading'}
+                className="btn-glass px-4 py-2 rounded-xl self-end disabled:opacity-50"
               >
-                {topics.map((t) => (
-                  <option key={t} value={t}>{t}</option>
-                ))}
-              </select>
-            </div>
-            <div className="flex flex-col flex-1 min-w-[150px]">
-              <label htmlFor="level" className="font-medium">Level</label>
-              <select
-                id="level"
-                className="mt-1 p-2 border rounded"
-                value={level}
-                onChange={(e) => setLevel(e.target.value as Level)}
-              >
-                {levels.map((l) => (
-                  <option key={l} value={l}>{l}</option>
-                ))}
-              </select>
-            </div>
-            <button
-              onClick={handleGenerate}
-              disabled={status === 'loading'}
-              className="self-end px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
-            >
-              Generate Lesson
-            </button>
-          </div>
-
-          {status === 'error' && (
-            <div className="p-3 mb-4 rounded bg-red-100 text-red-800 flex items-center justify-between">
-              <span>Couldn&apos;t generate a valid lesson. Try again.</span>
-              <button onClick={handleGenerate} className="ml-4 px-3 py-1 border rounded">
-                Retry
+                Generate Lesson
               </button>
             </div>
-          )}
 
-          {status === 'success' && lesson && (
-            <div>
-              <h2 className="text-xl font-semibold mb-2">{lesson.title}</h2>
-              <p className="text-sm text-gray-600 mb-4">{lesson.topic} • {lesson.level} • {lesson.duration_min} min</p>
-              <div className="mb-4">
-                {lesson.lesson.map(renderBlock)}
-              </div>
-              <div className="mb-4">
-                <h3 className="font-semibold mb-2">Example</h3>
-                {lesson.example.map(renderBlock)}
-              </div>
-              <div>
-                <h3 className="font-semibold mb-2">Exercise</h3>
-                <p className="mb-2">{lesson.exercise.question}</p>
-                <div className="space-y-2">
-                  {lesson.exercise.choices.map((choice, idx) => (
-                    <label key={idx} className="flex items-center gap-2">
-                      <input
-                        type="radio"
-                        name="exercise"
-                        value={idx}
-                        checked={selectedChoice === idx}
-                        onChange={() => setSelectedChoice(idx)}
-                      />
-                      <span>{choice}</span>
-                    </label>
-                  ))}
-                </div>
-                <button
-                  onClick={handleCheckAnswer}
-                  disabled={selectedChoice === null}
-                  className="mt-4 px-4 py-2 bg-green-600 text-white rounded disabled:opacity-50"
-                >
-                  Check Answer
+            {status === 'error' && (
+              <div className="card-glass p-3 mb-4 rounded-xl border-l-4 border-[var(--accent)] text-sm flex items-center justify-between">
+                <span>Couldn&apos;t generate a valid lesson. Try again.</span>
+                <button onClick={handleGenerate} className="btn-glass px-3 py-1 rounded-xl ml-4">
+                  Retry
                 </button>
-                <div className="mt-4" aria-live="polite">
-                  {grade === 'correct' && (
-                    <div className="p-3 rounded bg-green-100 text-green-800">{lesson.exercise.explain_correct}</div>
-                  )}
-                  {grade === 'incorrect' && (
-                    <div className="p-3 rounded bg-red-100 text-red-800">{lesson.exercise.explain_incorrect}</div>
-                  )}
+              </div>
+            )}
+
+            {status === 'success' && lesson && (
+              <div>
+                <h2 className="text-xl font-semibold mb-1">{lesson.title}</h2>
+                <p className="text-sm opacity-80 mb-4">{lesson.topic} • {lesson.level} • {lesson.duration_min} min</p>
+                <div className="mb-4">
+                  {lesson.lesson.map(renderBlock)}
+                </div>
+                <div className="mb-4">
+                  <h3 className="font-semibold mb-2">Example</h3>
+                  {lesson.example.map(renderBlock)}
+                </div>
+                <div>
+                  <h3 className="font-semibold mb-2">Exercise</h3>
+                  <p className="mb-2">{lesson.exercise.question}</p>
+                  <div className="space-y-2">
+                    {lesson.exercise.choices.map((choice, idx) => (
+                      <label key={idx} className="flex items-center gap-2">
+                        <input
+                          type="radio"
+                          name="exercise"
+                          value={idx}
+                          checked={selectedChoice === idx}
+                          onChange={() => setSelectedChoice(idx)}
+                          disabled={status === 'loading'}
+                        />
+                        <span>{choice}</span>
+                      </label>
+                    ))}
+                  </div>
+                  <button
+                    onClick={handleCheckAnswer}
+                    disabled={selectedChoice === null || status === 'loading'}
+                    className="btn-glass px-4 py-2 mt-4 rounded-xl disabled:opacity-50"
+                  >
+                    Check Answer
+                  </button>
+                  <div className="mt-4" aria-live="polite">
+                    {grade === 'correct' && (
+                      <div className="card-glass p-3 rounded-xl border-l-4 border-[var(--secondary)]">
+                        {lesson.exercise.explain_correct}
+                      </div>
+                    )}
+                    {grade === 'incorrect' && (
+                      <div className="card-glass p-3 rounded-xl border-l-4 border-[var(--accent)]">
+                        {lesson.exercise.explain_incorrect}
+                      </div>
+                    )}
+                  </div>
                 </div>
               </div>
-            </div>
-          )}
+            )}
+          </div>
         </div>
       </main>
 
       {status === 'loading' && (
-        <div className="fixed inset-0 flex flex-col items-center justify-center backdrop-blur-sm bg-gradient-to-br from-gray-700/40 to-gray-900/40">
-          <div className="w-16 h-16 bg-blue-600 rounded-full animate-breathe" />
-          <p className="mt-4 text-white">Generating your lesson…</p>
+        <div className="fixed inset-0 flex flex-col items-center justify-center glass-effect-strong bg-[var(--background)]/60">
+          <BreathingLoader />
+          <p className="mt-4">Generating your lesson…</p>
         </div>
       )}
     </div>

--- a/src/components/kaizen/BreathingLoader.tsx
+++ b/src/components/kaizen/BreathingLoader.tsx
@@ -1,0 +1,3 @@
+export default function BreathingLoader() {
+  return <div className="w-16 h-16 rounded-full bg-[var(--primary)] animate-breathe" />;
+}


### PR DESCRIPTION
## Summary
- add interactive Kaizen lesson demo page with dropdowns, loading overlay, and local exercise grading
- stub /api/lesson endpoint with deterministic 5% invalid responses
- add breathing loader component using existing design tokens

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cea6a523c832eb7b9aca217267d7b