### PR TITLE
Add Gemini-powered Kaizen lesson generator

### DIFF
--- a/src/app/api/lesson/route.ts
+++ b/src/app/api/lesson/route.ts
@@ -1,62 +1,54 @@
-import { NextResponse } from 'next/server';
-import type { LessonSchema } from '@/lib/lessonSchema';
+import { NextResponse } from 'next/server'
+import { createGoogleGenerativeAI } from '@ai-sdk/google'
+import { generateObject } from 'ai'
+import { lessonSchema, type LessonSchema } from '@/lib/lessonSchema'
 
-function shouldReturnInvalid(topic: LessonSchema['topic'], level: LessonSchema['level']) {
-  const key = (topic + level).split('').reduce((acc, c) => acc + c.charCodeAt(0), 0);
-  return key % 20 === 0;
+export const runtime = 'edge'
+export const dynamic = 'force-dynamic'
+
+const SYSTEM_PROMPT = `You are a precise curriculum generator. Return ONLY JSON matching LessonSchema. No prose. No markdown.`
+
+function buildPrompt(topic: LessonSchema['topic'], level: LessonSchema['level'], error?: string) {
+  const base = `Generate a beginner-friendly lesson for:\nTOPIC = "${topic}"\nLEVEL = "${level}"\n\nConstraints:\n- 8–12 minutes total.\n- 2–6 lesson blocks (text/code).\n- 1–3 example blocks.\n- Exercise: single_choice with 3–6 choices; include answer_index, explain_correct, explain_incorrect.\n- Avoid hallucinated facts; pick a narrowly defined subtopic if needed.`
+  return error ? `${base}\n\nThe previous output failed validation: ${error}` : base
 }
 
 export async function POST(req: Request) {
-  const { topic, level } = (await req.json()) as {
-    topic: LessonSchema['topic'];
-    level: LessonSchema['level'];
-  };
+  try {
+    const { topic, level } = (await req.json()) as {
+      topic: LessonSchema['topic']
+      level: LessonSchema['level']
+    }
 
-  await new Promise((res) => setTimeout(res, 1700));
+    const apiKey = process.env.GOOGLE_API_KEY
+    if (!apiKey) {
+      return NextResponse.json({ error: 'missing_api_key' }, { status: 500 })
+    }
 
-  if (shouldReturnInvalid(topic, level)) {
-    const invalid: Omit<LessonSchema, 'exercise'> & {
-      exercise: Omit<LessonSchema['exercise'], 'answer_index'>;
-    } = {
-      title: `${level} ${topic} Lesson`,
-      duration_min: 10,
-      topic,
-      level,
-      lesson: [{ type: 'text', content: `Intro to ${topic}.` }],
-      example: [{ type: 'text', content: `Example about ${topic}.` }],
-      exercise: {
-        question: `Sample question on ${topic}?`,
-        type: 'single_choice',
-        choices: ['Option A', 'Option B', 'Option C'],
-        explain_correct: 'Good job!',
-        explain_incorrect: 'Not quite.',
-      },
-    };
-    return NextResponse.json(invalid);
+    const google = createGoogleGenerativeAI({ apiKey })
+
+    let errorMessage = ''
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        const { object } = await generateObject({
+          model: google('models/gemini-1.5-flash-latest'),
+          temperature: 0.2,
+          system: SYSTEM_PROMPT,
+          prompt: buildPrompt(topic, level, errorMessage),
+          schema: lessonSchema,
+        })
+
+        await new Promise((res) => setTimeout(res, 1700))
+        return NextResponse.json(object)
+      } catch (err) {
+        errorMessage = err instanceof Error ? err.message : String(err)
+      }
+    }
+
+    return NextResponse.json({ error: 'validation_failed' }, { status: 502 })
+  } catch (error) {
+    console.error(error)
+    return NextResponse.json({ error: 'invalid_request' }, { status: 400 })
   }
-
-  const lesson: LessonSchema = {
-    title: `${level} ${topic} Basics`,
-    duration_min: 10,
-    topic,
-    level,
-    lesson: [
-      {
-        type: 'text',
-        content: `Welcome to ${topic}. This is a ${level.toLowerCase()} introduction.`,
-      },
-      { type: 'code', lang: 'text', content: `Code or formula snippet for ${topic}.` },
-    ],
-    example: [{ type: 'text', content: `Here's an example related to ${topic}.` }],
-    exercise: {
-      question: `What is 2 + 2?`,
-      type: 'single_choice',
-      choices: ['3', '4', '5'],
-      answer_index: 1,
-      explain_correct: '4 is the correct answer.',
-      explain_incorrect: 'Incorrect. The right answer is 4.',
-    },
-  };
-
-  return NextResponse.json(lesson);
 }
+


### PR DESCRIPTION
## Summary
- generate lessons with Google Gemini via new `/api/lesson` endpoint
- validate model output against `LessonSchema` and retry once on failure
- return structured JSON to power the Kaizen demo page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689cef204840832e910b1e331551fb2c