### PR TITLE
feat: animate mountain loader

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -159,6 +159,15 @@ body {
     }
 }
 
+@keyframes mountain-grow {
+    from {
+        transform: scale(0);
+    }
+    to {
+        transform: scale(1);
+    }
+}
+
 .animate-fade-in-up {
     animation: fade-in-up 0.8s ease-out forwards;
 }

--- a/src/components/kaizen/BreathingLoader.tsx
+++ b/src/components/kaizen/BreathingLoader.tsx
@@ -1,3 +1,23 @@
 export default function BreathingLoader() {
-  return <div className="w-16 h-16 rounded-full bg-[var(--primary)] animate-breathe" />;
+  return (
+    <div className="w-32 h-32">
+      <svg viewBox="0 0 100 100" className="w-full h-full">
+        <g className="origin-center animate-[mountain-grow_0.6s_ease-out_forwards]">
+          <path d="M10 90 L50 10 L90 90 Z" fill="black" />
+        </g>
+        <path id="runner-path" d="M20 90 L50 40 L80 90" fill="none" stroke="none" />
+        <g fill="white" stroke="white" strokeWidth="2">
+          <circle cx="0" cy="-3" r="3" fill="white" stroke="none" />
+          <path
+            d="M0 0 L0 6 M0 6 L-3 10 M0 6 L3 10 M0 2 L-3 4 M0 2 L3 0"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <animateMotion dur="3s" repeatCount="indefinite">
+            <mpath href="#runner-path" />
+          </animateMotion>
+        </g>
+      </svg>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- replace breathing circle loader with animated mountain and runner for lesson generation
- add CSS keyframes for mountain grow animation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Type error in src/app/kaizen/page.tsx:142:37)*

------
https://chatgpt.com/codex/tasks/task_e_689cfaa371e0832eb039c2abc8ee9e85