### PR TITLE
feat: add feature card and grid

### DIFF
--- a/src/components/atomic/molecules/FeatureCard.tsx
+++ b/src/components/atomic/molecules/FeatureCard.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from "react";
+import Subheading from "@/components/atomic/atoms/Subheading";
+
+interface FeatureCardProps {
+  icon?: ReactNode;
+  title: string;
+  description: string;
+}
+
+export default function FeatureCard({ icon, title, description }: FeatureCardProps) {
+  return (
+    <div className="flex flex-col items-center text-center gap-2 p-6 rounded-lg bg-[var(--card)] text-[var(--card-foreground)] border border-[var(--border)]">
+      {icon && <div className="text-3xl">{icon}</div>}
+      <Subheading className="mt-2">{title}</Subheading>
+      <p className="text-sm text-[var(--muted-foreground)]">{description}</p>
+    </div>
+  );
+}
+

--- a/src/components/atomic/organisms/FeatureGrid.tsx
+++ b/src/components/atomic/organisms/FeatureGrid.tsx
@@ -1,0 +1,55 @@
+import Container from "@/components/atomic/atoms/Container";
+import FeatureCard from "@/components/atomic/molecules/FeatureCard";
+
+const features = [
+  {
+    icon: "📘",
+    title: "Atomic lessons",
+    description: "bite-sized content",
+  },
+  {
+    icon: "🧾",
+    title: "Structured JSON",
+    description: "schema-first",
+  },
+  {
+    icon: "⚡",
+    title: "Local grading",
+    description: "instant feedback",
+  },
+  {
+    icon: "🔑",
+    title: "Bring your key",
+    description: "BYO Gemini/OpenAI",
+  },
+  {
+    icon: "🔥",
+    title: "Streaks & progress",
+    description: "stay consistent",
+  },
+  {
+    icon: "💻",
+    title: "Dev-friendly",
+    description: "typed schemas, Zod validation",
+  },
+];
+
+export default function FeatureGrid() {
+  return (
+    <section className="py-12">
+      <Container>
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {features.map((feature) => (
+            <FeatureCard
+              key={feature.title}
+              icon={feature.icon}
+              title={feature.title}
+              description={feature.description}
+            />
+          ))}
+        </div>
+      </Container>
+    </section>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `FeatureCard` molecule for icon, title, and description
- add `FeatureGrid` organism with six predefined features and responsive layout

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a58fe855a4832e820813074f3b9558