### PR TITLE
feat: add site footer component

### DIFF
--- a/src/components/atomic/organisms/SiteFooter.tsx
+++ b/src/components/atomic/organisms/SiteFooter.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+import Container from "@/components/atomic/atoms/Container";
+
+export default function SiteFooter() {
+  return (
+    <footer className="border-t border-[var(--border)] py-6 text-sm text-[var(--muted-foreground)]">
+      <Container className="flex flex-col items-center justify-between gap-4 sm:flex-row">
+        <div>© {new Date().getFullYear()} Brand</div>
+        <nav className="flex gap-4">
+          <Link href="https://github.com" target="_blank" rel="noopener noreferrer">
+            GitHub
+          </Link>
+          <Link href="/privacy">Privacy</Link>
+          <Link href="/terms">Terms</Link>
+        </nav>
+      </Container>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary
- add SiteFooter organism with GitHub, Privacy, and Terms links using Container and dark mode variables

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5943a6f88832ea855e2f684e773f6