### PR TITLE
feat: compose landing page from organisms

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
-import { redirect } from 'next/navigation';
+import LandingTemplate from "@/components/atomic/templates/LandingTemplate";
 
 export default function Home() {
-  redirect('/portfolio');
+  return <LandingTemplate />;
 }

--- a/src/components/atomic/organisms/FeatureGrid.tsx
+++ b/src/components/atomic/organisms/FeatureGrid.tsx
@@ -36,7 +36,7 @@ const features = [
 
 export default function FeatureGrid() {
   return (
-    <section className="py-12">
+    <section id="features" className="py-12 scroll-mt-24">
       <Container>
         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {features.map((feature) => (

--- a/src/components/atomic/organisms/HowItWorks.tsx
+++ b/src/components/atomic/organisms/HowItWorks.tsx
@@ -19,7 +19,7 @@ const steps = [
 
 export default function HowItWorks() {
   return (
-    <section id="how" className="py-12">
+    <section id="how" className="py-12 scroll-mt-24">
       <Container>
         <Heading className="text-center">How it works</Heading>
         <ol className="mt-8 flex flex-col md:flex-row gap-6 md:gap-4 list-none">

--- a/src/components/atomic/organisms/PricingTeaser.tsx
+++ b/src/components/atomic/organisms/PricingTeaser.tsx
@@ -6,7 +6,7 @@ import Button from "@/components/atomic/molecules/Button";
 
 export default function PricingTeaser() {
   return (
-    <section id="pricing" className="py-12">
+    <section id="pricing" className="py-12 scroll-mt-24">
       <Container>
         <Heading className="text-center">Pricing</Heading>
         <div className="mt-8 grid gap-6 sm:grid-cols-2">

--- a/src/components/atomic/templates/LandingTemplate.tsx
+++ b/src/components/atomic/templates/LandingTemplate.tsx
@@ -1,0 +1,24 @@
+import SiteHeader from "@/components/atomic/organisms/SiteHeader";
+import Hero from "@/components/atomic/organisms/Hero";
+import FeatureGrid from "@/components/atomic/organisms/FeatureGrid";
+import HowItWorks from "@/components/atomic/organisms/HowItWorks";
+import CodeShowcase from "@/components/atomic/organisms/CodeShowcase";
+import PricingTeaser from "@/components/atomic/organisms/PricingTeaser";
+import SiteFooter from "@/components/atomic/organisms/SiteFooter";
+
+export default function LandingTemplate() {
+  return (
+    <>
+      <SiteHeader />
+      <main>
+        <Hero />
+        <FeatureGrid />
+        <HowItWorks />
+        <CodeShowcase />
+        <PricingTeaser />
+      </main>
+      <SiteFooter />
+    </>
+  );
+}
+


### PR DESCRIPTION
## Summary
- compose LandingTemplate with hero, features, how-to, showcase, pricing, and footer
- expose landing template on root page
- enable anchored sections with scroll offsets for smooth navigation

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5962c0144832e806511daf0b85862