### PR TITLE
feat: add AI lesson intro page and update routing

### DIFF
--- a/src/app/ai-lesson/page.tsx
+++ b/src/app/ai-lesson/page.tsx
@@ -1,0 +1,5 @@
+import AiLessonTemplate from "@/components/atomic/templates/AiLessonTemplate";
+
+export default function AiLessonPage() {
+  return <AiLessonTemplate />;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
-import LandingTemplate from "@/components/atomic/templates/LandingTemplate";
+import PortfolioPage from "./portfolio/page";
 
 export default function Home() {
-  return <LandingTemplate />;
+  return <PortfolioPage />;
 }

--- a/src/components/atomic/templates/AiLessonTemplate.tsx
+++ b/src/components/atomic/templates/AiLessonTemplate.tsx
@@ -1,0 +1,21 @@
+import SiteHeader from "@/components/atomic/organisms/SiteHeader";
+import SiteFooter from "@/components/atomic/organisms/SiteFooter";
+
+export default function AiLessonTemplate() {
+  return (
+    <>
+      <SiteHeader />
+      <main className="max-w-3xl mx-auto px-4 py-16 text-center">
+        <h1 className="text-4xl font-bold mb-6">Learning AI Project</h1>
+        <p className="mb-8">
+          Discover the AI lesson generator built with Next.js. Generate
+          custom lessons across topics and difficulty levels.
+        </p>
+        <a href="/kaizen" className="btn-glass px-6 py-3 rounded-xl">
+          Try Kaizen
+        </a>
+      </main>
+      <SiteFooter />
+    </>
+  );
+}

--- a/src/components/portfolio/sections/ProjectSection.tsx
+++ b/src/components/portfolio/sections/ProjectSection.tsx
@@ -73,16 +73,16 @@ const ProjectsSection: React.FC = () => {
       featured: false,
       gradient: 'from-orange-500 to-red-600',
     },
-    {
-      title: 'Learning AI',
-      description: 'Exploring artificial intelligence concepts and applications.',
-      technologies: ['Next.js', 'AI'],
-      image: '/AILesson.png',
-      github: '#',
-      demo: '/kaizen',
-      featured: false,
-    },
-  ];
+      {
+        title: 'Learning AI',
+        description: 'Exploring artificial intelligence concepts and applications.',
+        technologies: ['Next.js', 'AI'],
+        image: '/AILesson.png',
+        github: '#',
+        demo: '/ai-lesson',
+        featured: false,
+      },
+    ];
 
   return (
     <section 


### PR DESCRIPTION
## Summary
- make portfolio page the root route
- introduce AI lesson intro page linking to Kaizen demo
- update project section to point demo to new route

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a59d1a9a10832e966cf31df222434b