### PR TITLE
feat: hero backdrop with KAIZEN watermark

### DIFF
--- a/public/kaizen-mark.svg
+++ b/public/kaizen-mark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none" stroke="currentColor" stroke-width="8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M20 20v60M20 50l40-30M20 50l40 30"/>
+</svg>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -360,3 +360,34 @@ img {
 .typewriter-caret {
   animation: caret-blink 1s steps(1) infinite;
 }
+/* ---- Hero backdrop utilities ---- */
+:root{
+  --hero-bg: radial-gradient(1200px 600px at 50% 10%, rgba(16,185,129,0.10), transparent 60%),
+             radial-gradient(800px 400px at 10% 20%, rgba(16,185,129,0.06), transparent 60%),
+             radial-gradient(800px 400px at 90% 30%, rgba(16,185,129,0.06), transparent 60%),
+             linear-gradient(#ffffff, #ffffff);
+}
+
+/* sub‑pixel dot grid (ultra faint) */
+.hero-dots {
+  background-image:
+    radial-gradient(circle at 1px 1px, rgba(0,0,0,.06) 1px, transparent 0);
+  background-size: 28px 28px;
+}
+
+/* vignette ring for focus */
+.hero-vignette {
+  position: relative;
+}
+.hero-vignette::after{
+  content:"";
+  position:absolute; inset:-20vmax;
+  background: radial-gradient(50% 50% at 50% 40%, rgba(0,0,0,.06), transparent 60%);
+  pointer-events:none;
+}
+
+/* motion-safe fade in */
+@media (prefers-reduced-motion: no-preference){
+  .hero-fade-in { animation: heroFade .9s ease-out both; }
+  @keyframes heroFade { from { opacity:0; transform: translateY(8px) } to { opacity:1; transform:none } }
+}

--- a/src/components/dna/background/HeroBackdrop.tsx
+++ b/src/components/dna/background/HeroBackdrop.tsx
@@ -1,0 +1,24 @@
+"use client";
+import Image from "next/image";
+
+export default function HeroBackdrop(){
+  return (
+    <div className="absolute inset-0 -z-10 hero-vignette">
+      {/* color field */}
+      <div className="absolute inset-0" style={{ backgroundImage: "var(--hero-bg)" }} />
+      {/* faint dot grid */}
+      <div className="absolute inset-0 hero-dots opacity-[.06]" />
+
+      {/* KAIZEN watermark */}
+      <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+        <div className="opacity-10">
+          <Image
+            src="/kaizen-mark.svg"
+            alt="" width={720} height={720} priority
+            className="w-[60vw] max-w-[720px] h-auto"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/portfolio/sections/HeroSection.tsx
+++ b/src/components/portfolio/sections/HeroSection.tsx
@@ -1,53 +1,39 @@
-'use client';
+"use client";
 
-import Image from 'next/image';
-import Link from 'next/link';
-import { Button } from '@/components/dna/button';
-import { Container } from '@/components/dna/layout';
-import { Heading, Text } from '@/components/dna/typography';
-import GlassPanel from '@/components/dna/glass/GlassPanel';
-import Typewriter from '@/components/dna/animations/Typewriter';
+import Link from "next/link";
+import GlassPanel from "@/components/dna/glass/GlassPanel";
+import HeroBackdrop from "@/components/dna/background/HeroBackdrop";
+import { Button } from "@/components/dna/button";
+import { Heading, Text } from "@/components/dna/typography";
 
-export default function HeroSection() {
+export default function HeroSection(){
   return (
-    <section
-      id="hero"
-      className="flex min-h-screen items-center bg-gradient-to-b from-white via-green-50 to-white py-16 md:py-24"
-    >
-      <Container>
-        <GlassPanel className="flex flex-col items-center justify-between gap-12 text-center md:flex-row md:text-left">
-          <div className="space-y-6 md:flex-1">
-            <Heading as="h1" className="text-gray-900">
-              <Typewriter text="Building SaaS for SMEs." />
+    <section id="hero" className="relative py-24 md:py-32 overflow-hidden">
+      <HeroBackdrop />
+      <div className="container mx-auto px-4 hero-fade-in">
+        <div className="mx-auto max-w-3xl text-center">
+          <GlassPanel className="mx-auto">
+            <Heading as="h1" className="text-5xl md:text-7xl font-bold tracking-tight text-gray-900">
+              KAIZEN learning & SaaS delivery
             </Heading>
-            <Text className="text-gray-600">
-              Secure, data-driven, and fast to ship — from idea to production.
+            <Text className="mt-4 text-lg md:text-xl text-gray-600">
+              Secure, data‑driven, and fast to ship — from idea to production.
             </Text>
-            <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
-              <Link href="/contact">
-                <Button size="lg" animation="roll-replace">
+            <div className="mt-8 flex items-center justify-center gap-3">
+              <Link href="/contact" aria-label="Start a project">
+                <Button variant="primary" size="lg" animation="roll-replace">
                   Start a project
                 </Button>
               </Link>
-              <Link href="#projects">
-                <Button variant="secondary" size="lg" animation="roll-replace">
+              <Link href="#projects" aria-label="See case studies">
+                <Button variant="ghost" size="lg" animation="roll-replace">
                   See case studies
                 </Button>
               </Link>
             </div>
-          </div>
-          <GlassPanel className="w-full max-w-lg h-72 md:flex-1 overflow-hidden">
-            <Image
-              src="/ProjectAI.png"
-              alt="App screenshot"
-              className="h-full w-full object-cover"
-              width={800}
-              height={600}
-              priority
-            />
           </GlassPanel>
-        </GlassPanel>
-      </Container>
+        </div>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- add KAIZEN mark asset and background utilities
- implement HeroBackdrop and centered GlassPanel hero

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5dca82db0832eabb86cd239fc9137