### PR TITLE
feat: darker hero backdrop with halo

### DIFF
--- a/public/kaizen-mark.svg
+++ b/public/kaizen-mark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none" stroke="currentColor" stroke-width="12" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M20 20v60M20 50h40l20 30M20 50L60 20"/>
+</svg>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,32 +1,23 @@
 @import 'tailwindcss';
 
 :root {
-    --predominant: #0b243c;
-    --background: #f6edcd;
-    --surface: rgba(246, 237, 205, 0.8);
-    --surface-glass: rgba(246, 237, 205, 0.4);
-    --mountain-primary: #b4d2cb;
-    --mountain-secondary: #80b0b5;
-    --mountain-tertiary: #c7dbcf;
-
-    --glass-bg: rgba(246, 237, 205, 0.1);
-    --glass-border: rgba(11, 36, 60, 0.1);
-    --glass-shadow: rgba(11, 36, 60, 0.1);
-
-    --foreground: var(--predominant);
-    --card: rgba(246, 237, 205, 0.6);
-    --card-foreground: var(--predominant);
-    --primary: var(--predominant);
-    --primary-foreground: var(--background);
-    --secondary: var(--mountain-primary);
-    --secondary-foreground: var(--predominant);
-    --muted: var(--mountain-tertiary);
-    --muted-foreground: var(--predominant);
-    --accent: var(--mountain-secondary);
-    --accent-foreground: var(--predominant);
-    --border: rgba(11, 36, 60, 0.15);
-    --input: rgba(11, 36, 60, 0.1);
-    --ring: var(--predominant);
+    --background: #ffffff;
+    --foreground: #000000;
+    --primary: #10b981;
+    --primary-foreground: #ffffff;
+    --secondary: #f3f4f6;
+    --secondary-foreground: #111827;
+    --muted: #f3f4f6;
+    --muted-foreground: #6b7280;
+    --card: #ffffff;
+    --card-foreground: #000000;
+    --border: rgba(0, 0, 0, 0.1);
+    --input: rgba(0, 0, 0, 0.05);
+    --ring: #10b981;
+    --glass-bg: rgba(255, 255, 255, 0.6);
+    --glass-border: rgba(0, 0, 0, 0.1);
+    --glass-shadow: rgba(0, 0, 0, 0.05);
+    --surface-glass: rgba(255, 255, 255, 0.4);
 }
 
 
@@ -290,15 +281,6 @@ img {
   .btn[data-anim="roll-replace"]:hover .btn-text-front { opacity: .85; text-decoration: underline; }
 }
 
-:root {
-  --background: #ffffff;
-  --foreground: #111827;
-  --primary: #10b981;
-  --primary-foreground: #ffffff;
-  --secondary: #f3f4f6;
-  --secondary-foreground: #111827;
-}
-
 /* ---- iOS-like Glass Utilities ---- */
 
 /* Tiny noise (base64) to avoid external asset; super subtle */
@@ -360,3 +342,91 @@ img {
 .typewriter-caret {
   animation: caret-blink 1s steps(1) infinite;
 }
+/* motion-safe fade in */
+@media (prefers-reduced-motion: no-preference){
+  .hero-fade-in { animation: heroFade .9s ease-out both; }
+  @keyframes heroFade { from { opacity:0; transform: translateY(8px) } to { opacity:1; transform:none } }
+}
+
+/* ---- Hero backdrop utilities ---- */
+:root{
+  /* Deeper emeralds with subtle teal for depth */
+  --hero-bg:
+    radial-gradient(1200px 680px at 50% 8%, rgba(12,133,93,0.22), transparent 60%),
+    radial-gradient(900px 520px at 12% 25%, rgba(12,133,93,0.12), transparent 60%),
+    radial-gradient(900px 520px at 88% 28%, rgba(15,118,110,0.10), transparent 60%),
+    linear-gradient(#f9fafb, #ffffff);
+}
+
+/* sub‑pixel dot grid (ultra faint) */
+.hero-dots {
+  background-image:
+    radial-gradient(circle at 1px 1px, rgba(0,0,0,.06) 1px, transparent 0);
+  background-size: 28px 28px;
+}
+
+/* vignette ring for focus */
+.hero-vignette {
+  position: relative;
+}
+.hero-vignette::after{
+  content:"";
+  position:absolute; inset:-20vmax;
+  background: radial-gradient(50% 50% at 50% 40%, rgba(0,0,0,.10), transparent 62%);
+  pointer-events:none;
+}
+
+/* ---- iOS-like Glass: edge-lit tuning ---- */
+:root{
+  --glass-fill-1: rgba(255,255,255,0.46); /* slightly more transparent center */
+  --glass-fill-2: rgba(255,255,255,0.28);
+  --glass-border: rgba(255,255,255,0.26); /* hairline */
+  --glass-edge-light: rgba(255,255,255,0.55); /* edge highlight */
+  --glass-edge-shadow: rgba(0,0,0,0.06);      /* faint inner shadow */
+}
+
+/* Base glass */
+.glass {
+  position: relative;
+  background-image: linear-gradient(135deg, var(--glass-fill-1), var(--glass-fill-2));
+  border: 1px solid var(--glass-border);
+  -webkit-backdrop-filter: blur(16px) saturate(1.35);
+  backdrop-filter: blur(16px) saturate(1.35);
+  box-shadow:
+    inset 0 1px 0 var(--glass-edge-light), /* top inner light */
+    0 0 0 1px rgba(255,255,255,0.18),      /* hairline outer */
+    0 18px 38px rgba(0,0,0,0.08);          /* ambient */
+}
+
+/* Edge emphasis: a feathered rim around the panel */
+.glass::before {
+  content:""; pointer-events:none;
+  position:absolute; inset:0; border-radius:inherit;
+  background:
+    radial-gradient(120% 140% at 0% 0%, rgba(255,255,255,.22), transparent 50%),
+    radial-gradient(120% 140% at 100% 0%, rgba(255,255,255,.18), transparent 50%),
+    radial-gradient(120% 140% at 0% 100%, rgba(255,255,255,.14), transparent 50%),
+    radial-gradient(120% 140% at 100% 100%, rgba(255,255,255,.14), transparent 50%),
+    radial-gradient(80% 80% at 50% 50%, rgba(0,0,0,.06), transparent 60%); /* inner shadow */
+  mix-blend-mode: screen;
+  opacity:.8;
+}
+
+/* Micro-noise stays very subtle */
+.glass::after {
+  content:""; pointer-events:none; position:absolute; inset:0; border-radius:inherit;
+  background-image: var(--glass-noise); background-size: 120px 120px; opacity:.05;
+}
+
+/* Motion safety */
+@media (prefers-reduced-motion: reduce) {
+  .glass, .glass::before, .glass::after { transition:none !important; }
+}
+
+@media (prefers-reduced-motion: no-preference){
+  @keyframes halo-rotate {
+    from { transform: rotate(0deg); }
+    to   { transform: rotate(360deg); }
+  }
+}
+

--- a/src/components/dna/background/HeroBackdrop.tsx
+++ b/src/components/dna/background/HeroBackdrop.tsx
@@ -1,0 +1,21 @@
+"use client";
+import KaizenHalo from "@/components/dna/background/KaizenHalo";
+import Image from "next/image";
+
+export default function HeroBackdrop(){
+  return (
+    <div className="absolute inset-0 -z-10 hero-vignette">
+      <div className="absolute inset-0" style={{ backgroundImage: "var(--hero-bg)" }} />
+      <div className="absolute inset-0 hero-dots opacity-[.06]" />
+
+      {/* Center watermark + halo */}
+      <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+        <div className="relative">
+          <KaizenHalo size={720} thickness={3} glow opacity={0.12} className="hidden md:block" />
+          <Image src="/kaizen-mark.svg" alt="" width={720} height={720} priority
+                 className="w-[60vw] max-w-[720px] h-auto opacity-10" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dna/background/KaizenHalo.tsx
+++ b/src/components/dna/background/KaizenHalo.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+function clsx(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+ type Props = React.HTMLAttributes<HTMLDivElement> & {
+  size?: number;        // px, default 760
+  thickness?: number;   // px, default 2
+  glow?: boolean;       // adds outer glow
+  opacity?: number;     // 0..1, default 0.10
+};
+
+export default function KaizenHalo({ size=760, thickness=2, glow=true, opacity=0.10, className, ...rest }: Props){
+  const style: React.CSSProperties = {
+    width: size, height: size,
+    '--halo-thickness': `${thickness}px`,
+    '--halo-opacity': opacity.toString(),
+  } as any;
+
+  return (
+    <div
+      {...rest}
+      aria-hidden
+      className={clsx(
+        "relative pointer-events-none select-none",
+        "[@media(prefers-reduced-motion:no-preference)]:animate-[halo-rotate_9s_linear_infinite]",
+        className
+      )}
+      style={style}
+    >
+      {/* LED ring using conic-gradient */}
+      <div className="absolute inset-0 rounded-full"
+        style={{
+          mask: "radial-gradient(farthest-side, transparent calc(100% - var(--halo-thickness)), #000 calc(100% - var(--halo-thickness)))",
+          WebkitMask: "radial-gradient(farthest-side, transparent calc(100% - var(--halo-thickness)), #000 calc(100% - var(--halo-thickness)))",
+          background: "conic-gradient(from 0deg, rgba(16,185,129,0) 0deg, rgba(16,185,129,.7) 30deg, rgba(16,185,129,0) 60deg, rgba(16,185,129,0) 360deg)",
+          opacity: "var(--halo-opacity)"
+        }}
+      />
+      {glow && (
+        <div className="absolute inset-0 rounded-full blur-xl"
+          style={{
+            background: "conic-gradient(from 0deg, rgba(16,185,129,0) 0deg, rgba(16,185,129,.35) 30deg, rgba(16,185,129,0) 60deg 360deg)",
+            opacity: "calc(var(--halo-opacity) * .8)"
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/dna/button/Button.tsx
+++ b/src/components/dna/button/Button.tsx
@@ -9,9 +9,9 @@ export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
 };
 
 const variantClasses: Record<string, string> = {
-  primary: "bg-[var(--primary)] text-[var(--primary-foreground)]",
+  primary: "bg-[var(--primary)] text-[var(--primary-foreground)] hover:bg-emerald-600",
   secondary: "bg-[var(--secondary)] text-[var(--secondary-foreground)]",
-  ghost: "bg-transparent text-[var(--foreground)]",
+  ghost: "bg-transparent text-[var(--primary)] border border-[var(--primary)] hover:bg-[var(--primary)] hover:text-[var(--primary-foreground)]",
   glass: "glass text-gray-900",
 };
 

--- a/src/components/dna/glass/GlassPanel.tsx
+++ b/src/components/dna/glass/GlassPanel.tsx
@@ -2,18 +2,19 @@
 
 import React from "react";
 
+function clsx(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(" ");
+}
+
 export type GlassPanelProps = React.HTMLAttributes<HTMLDivElement> & {
   sheen?: boolean;
 };
 
-export default function GlassPanel({ className = "", sheen = true, ...rest }: GlassPanelProps) {
-  const classes = [
-    "glass rounded-2xl p-6 md:p-8 drop-shadow-glass",
-    sheen && "sheen",
-    className,
-  ]
-    .filter(Boolean)
-    .join(" ");
-
-  return <div className={classes} {...rest} />;
+export default function GlassPanel({ className, sheen = true, ...rest }: GlassPanelProps) {
+  return (
+    <div
+      {...rest}
+      className={clsx("glass rounded-2xl p-6 md:p-8", sheen && "sheen", className)}
+    />
+  );
 }

--- a/src/components/portfolio/sections/HeroSection.tsx
+++ b/src/components/portfolio/sections/HeroSection.tsx
@@ -1,53 +1,39 @@
-'use client';
+"use client";
 
-import Image from 'next/image';
-import Link from 'next/link';
-import { Button } from '@/components/dna/button';
-import { Container } from '@/components/dna/layout';
-import { Heading, Text } from '@/components/dna/typography';
-import GlassPanel from '@/components/dna/glass/GlassPanel';
-import Typewriter from '@/components/dna/animations/Typewriter';
+import Link from "next/link";
+import GlassPanel from "@/components/dna/glass/GlassPanel";
+import HeroBackdrop from "@/components/dna/background/HeroBackdrop";
+import { Button } from "@/components/dna/button";
+import { Heading, Text } from "@/components/dna/typography";
 
-export default function HeroSection() {
+export default function HeroSection(){
   return (
-    <section
-      id="hero"
-      className="flex min-h-screen items-center bg-gradient-to-b from-white via-green-50 to-white py-16 md:py-24"
-    >
-      <Container>
-        <GlassPanel className="flex flex-col items-center justify-between gap-12 text-center md:flex-row md:text-left">
-          <div className="space-y-6 md:flex-1">
-            <Heading as="h1" className="text-gray-900">
-              <Typewriter text="Building SaaS for SMEs." />
+    <section id="hero" className="relative py-24 md:py-32 overflow-hidden">
+      <HeroBackdrop />
+      <div className="container mx-auto px-4 hero-fade-in">
+        <div className="mx-auto max-w-3xl text-center">
+          <GlassPanel className="mx-auto">
+            <Heading as="h1" className="text-5xl md:text-7xl font-bold tracking-tight text-gray-900">
+              KAIZEN learning & SaaS delivery
             </Heading>
-            <Text className="text-gray-600">
-              Secure, data-driven, and fast to ship — from idea to production.
+            <Text className="mt-4 text-lg md:text-xl text-gray-600">
+              Secure, data‑driven, and fast to ship — from idea to production.
             </Text>
-            <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
-              <Link href="/contact">
-                <Button size="lg" animation="roll-replace">
+            <div className="mt-8 flex items-center justify-center gap-3">
+              <Link href="/contact" aria-label="Start a project">
+                <Button variant="primary" size="lg" animation="roll-replace">
                   Start a project
                 </Button>
               </Link>
-              <Link href="#projects">
-                <Button variant="secondary" size="lg" animation="roll-replace">
+              <Link href="#projects" aria-label="See case studies">
+                <Button variant="ghost" size="lg" animation="roll-replace">
                   See case studies
                 </Button>
               </Link>
             </div>
-          </div>
-          <GlassPanel className="w-full max-w-lg h-72 md:flex-1 overflow-hidden">
-            <Image
-              src="/ProjectAI.png"
-              alt="App screenshot"
-              className="h-full w-full object-cover"
-              width={800}
-              height={600}
-              priority
-            />
           </GlassPanel>
-        </GlassPanel>
-      </Container>
+        </div>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- deepen hero backdrop with emerald gradients and vignette, backed by a KAIZEN watermark and rotating halo
- tune glass panel styling for brighter edges and translucent center
- introduce reusable KaizenHalo component and watermark SVG asset

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5dca82db0832eabb86cd239fc9137