### PR TITLE
feat: add kaizen assemble backdrop

### DIFF
--- a/public/kaizen-kanji-solid.svg
+++ b/public/kaizen-kanji-solid.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 360" fill="currentColor">
+  <rect width="720" height="360" fill="none" />
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="300" font-family="sans-serif">改善</text>
+</svg>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -429,3 +429,105 @@ img {
     to   { transform: rotate(360deg); }
   }
 }
+
+/* === KAIZEN Assemble Background Animation (motion-safe) === */
+:root{
+  --kaizen-emerald: #10b981;
+  --kaizen-loop: 8s;        /* total cycle */
+  --kaizen-enter: 2.4s;     /* slide-in duration */
+  --kaizen-hold: 1.3s;      /* time assembled before reset */
+  --kaizen-delay: 0.4s;     /* initial delay for stagger */
+}
+
+/* Container for the two halves */
+.kaizen-bg {
+  position: absolute;
+  inset: 0;
+  z-index: -10;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+/* Shared style for each half (we animate via transform only) */
+.kaizen-half {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: min(72vw, 720px);
+  translate: -50% -50%;
+  opacity: 0.10; /* faint watermark */
+  will-change: transform, opacity;
+}
+
+/* Masks built with clip-path so we can use the same SVG twice */
+.kaizen-left { clip-path: inset(0 50% 0 0); }
+.kaizen-right{ clip-path: inset(0 0 0 50%); }
+
+/* Left slides from off-screen left to center */
+@keyframes kaizenSlideInLeft {
+  0%   { transform: translateX(-45vw) scale(1); opacity: .08; }
+  60%  { transform: translateX(0)     scale(1); opacity: .10; }
+  100% { transform: translateX(0)     scale(1); opacity: .10; }
+}
+
+/* Right slides from off-screen right to center */
+@keyframes kaizenSlideInRight {
+  0%   { transform: translateX(45vw)  scale(1); opacity: .08; }
+  60%  { transform: translateX(0)     scale(1); opacity: .10; }
+  100% { transform: translateX(0)     scale(1); opacity: .10; }
+}
+
+/* Emerald flash in the center when they meet (short and subtle) */
+.kaizen-flash {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: min(22vw, 220px);
+  height: min(22vw, 220px);
+  translate: -50% -50%;
+  border-radius: 9999px;
+  background: radial-gradient(closest-side, color-mix(in oklab, var(--kaizen-emerald) 65%, white 35%) 0%, transparent 70%);
+  filter: blur(18px);
+  opacity: 0;
+  pointer-events: none;
+  will-change: opacity, transform;
+}
+
+@keyframes kaizenFlashPulse {
+  0%   { opacity: 0; transform: scale(.85); }
+  60%  { opacity: .55; transform: scale(1.05); }
+  100% { opacity: 0; transform: scale(1.15); }
+}
+
+/* Orchestrate the loop with delays so it breathes:
+   - slide in to 60% of timeline
+   - flash triggers near 60–72%
+   - hold assembled
+   - reset (via opacity off-screen jump is hidden by overflow)
+*/
+.kaizen-left {
+  animation:
+    kaizenSlideInLeft var(--kaizen-enter) cubic-bezier(.2,.8,.2,1) var(--kaizen-delay) forwards,
+    kaizenSlideInLeft var(--kaizen-loop) linear infinite;
+}
+.kaizen-right {
+  animation:
+    kaizenSlideInRight var(--kaizen-enter) cubic-bezier(.2,.8,.2,1) var(--kaizen-delay) forwards,
+    kaizenSlideInRight var(--kaizen-loop) linear infinite;
+}
+.kaizen-flash {
+  animation:
+    kaizenFlashPulse calc(var(--kaizen-enter) * .6) ease-out calc(var(--kaizen-delay) + var(--kaizen-enter) * .6) both,
+    kaizenFlashPulse var(--kaizen-loop) ease-out infinite;
+}
+
+/* Reduced motion: show assembled state, no motion; mild static glow */
+@media (prefers-reduced-motion: reduce) {
+  .kaizen-left,
+  .kaizen-right,
+  .kaizen-flash { animation: none !important; }
+  .kaizen-left,
+  .kaizen-right { transform: translateX(0) !important; opacity: .10; }
+  .kaizen-flash { opacity: .16; filter: blur(12px); }
+}
+

--- a/src/components/dna/background/KaizenAssembleBackdrop.tsx
+++ b/src/components/dna/background/KaizenAssembleBackdrop.tsx
@@ -1,0 +1,36 @@
+"use client";
+import Image from "next/image";
+
+export default function KaizenAssembleBackdrop() {
+  return (
+    <div className="kaizen-bg">
+      {/* Left half (masked) */}
+      <div className="kaizen-half kaizen-left">
+        <Image
+          src="/kaizen-kanji-solid.svg"
+          alt=""
+          width={720}
+          height={360}
+          priority
+          className="w-[min(72vw,720px)] h-auto select-none pointer-events-none"
+        />
+      </div>
+
+      {/* Right half (masked) */}
+      <div className="kaizen-half kaizen-right">
+        <Image
+          src="/kaizen-kanji-solid.svg"
+          alt=""
+          width={720}
+          height={360}
+          priority
+          className="w-[min(72vw,720px)] h-auto select-none pointer-events-none"
+        />
+      </div>
+
+      {/* Center flash */}
+      <div className="kaizen-flash" />
+    </div>
+  );
+}
+

--- a/src/components/portfolio/sections/HeroSection.tsx
+++ b/src/components/portfolio/sections/HeroSection.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import GlassPanel from "@/components/dna/glass/GlassPanel";
 import HeroBackdrop from "@/components/dna/background/HeroBackdrop";
+import KaizenAssembleBackdrop from "@/components/dna/background/KaizenAssembleBackdrop";
 import { Button } from "@/components/dna/button";
 import { Heading, Text } from "@/components/dna/typography";
 
@@ -10,6 +11,7 @@ export default function HeroSection(){
   return (
     <section id="hero" className="relative py-24 md:py-32 overflow-hidden">
       <HeroBackdrop />
+      <KaizenAssembleBackdrop />
       <div className="container mx-auto px-4 hero-fade-in">
         <div className="mx-auto max-w-3xl text-center">
           <GlassPanel className="mx-auto">


### PR DESCRIPTION
## Summary
- add global Kaizen assemble animation styles
- introduce KaizenAssembleBackdrop component and mount in hero
- add missing kaizen-kanji-solid.svg asset

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in KaizenHalo.tsx)*
- `npx next lint --file src/components/portfolio/sections/HeroSection.tsx --file src/components/dna/background/KaizenAssembleBackdrop.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a6dcbcfa58832ea436d13a720e5503