### PR TITLE
feat: add interactive about timeline

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,22 @@
+import dynamic from "next/dynamic";
+
+const ParcoursTimeline = dynamic(
+  () => import("@/components/about/ParcoursTimeline"),
+  { ssr: false }
+);
+
+export default function AboutPage() {
+  return (
+    <main style={{ minHeight: "200vh" }}>
+      <section style={{ padding: "6rem 1rem 2rem", textAlign: "center" }}>
+        <h1>À propos</h1>
+        <p>
+          Ingénieur full‑stack orienté data & UX. J’aime les systèmes élégants,
+          mesurables et scalables.
+        </p>
+      </section>
+      <ParcoursTimeline />
+    </main>
+  );
+}
+

--- a/src/components/about/ParcoursTimeline.module.css
+++ b/src/components/about/ParcoursTimeline.module.css
@@ -1,0 +1,158 @@
+:root {
+  --bg: rgba(255,255,255,0.06);
+  --glass: rgba(255,255,255,0.12);
+  --stroke: rgba(255,255,255,0.25);
+  --accent: #00e676;
+  --shadow: rgba(0,0,0,0.35);
+}
+
+.wrapper {
+  position: relative;
+  padding: 8rem 1rem 10rem;
+  max-width: 1100px;
+  margin: 0 auto;
+  perspective: 1200px;
+}
+
+.rail {
+  position: fixed;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  height: 100vh;
+  width: 6px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.segment {
+  width: 4px;
+  height: calc(100vh / 28 - 2px);
+  margin: 1px 0;
+  background: radial-gradient(circle, var(--accent) 0%, transparent 65%);
+  opacity: calc(0.18 + var(--glow, 0) * 0.72);
+  filter: blur(calc(1px + var(--glow, 0) * 1.5px));
+  border-radius: 2px;
+  transition: opacity 120ms linear, filter 120ms linear;
+}
+
+.zigzag {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  position: relative;
+  z-index: 1;
+}
+
+.item {
+  position: relative;
+  display: grid;
+  grid-template-columns: 1fr;
+  align-items: center;
+  margin: 6rem 0;
+}
+
+@media (min-width: 800px) {
+  .item {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.left  { grid-template-areas: "card ."; }
+.right { grid-template-areas: ". card"; }
+
+.card {
+  grid-area: card;
+  background: linear-gradient(180deg, var(--bg), transparent 140%),
+              linear-gradient(to right, rgba(255,255,255,0.08), rgba(255,255,255,0.03));
+  border: 1px solid var(--stroke);
+  backdrop-filter: blur(8px);
+  border-radius: 16px;
+  padding: 1.25rem 1.25rem 1.5rem;
+  box-shadow: 0 12px 30px var(--shadow), inset 0 0 0 1px rgba(255,255,255,0.05);
+  transform-style: preserve-3d;
+  transform: translateZ(0) rotateX(0) rotateY(0);
+  transition: transform 220ms ease, box-shadow 220ms ease, border-color 220ms ease;
+  will-change: transform;
+}
+
+.card:hover,
+.card:focus {
+  transform: translateZ(22px) rotateX(2deg) rotateY(var(--tilt, 0deg));
+  box-shadow: 0 18px 50px rgba(0,0,0,0.45), 0 0 22px -4px var(--accent);
+  border-color: color-mix(in oklab, var(--stroke) 60%, var(--accent));
+}
+.card:active {
+  transform: translateZ(10px) rotateX(0.5deg) rotateY(0deg) scale(0.995);
+}
+
+.card::after {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  border-radius: 16px;
+  background: radial-gradient(120px 60px at 80% 10%, rgba(0,230,118,0.25), transparent 45%),
+              radial-gradient(160px 100px at 10% 90%, rgba(0,230,118,0.18), transparent 55%);
+  mix-blend-mode: screen;
+  pointer-events: none;
+  filter: blur(8px);
+}
+
+.cardHeader { margin-bottom: 0.4rem; }
+.title   { margin: 0 0 0.2rem; font-weight: 700; font-size: 1.15rem; }
+.subtitle{ margin: 0; opacity: 0.85; }
+.period  { font-size: 0.9rem; opacity: 0.75; }
+
+.bullets { margin: 0.6rem 0 0; padding-left: 1rem; line-height: 1.35; }
+.bullets li { margin: 0.15rem 0; }
+
+.cornerTag {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  font-size: 0.8rem;
+  opacity: 0.6;
+}
+
+.connector {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%,-50%);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  pointer-events: none;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--accent);
+  box-shadow: 0 0 10px var(--accent), 0 0 30px rgba(0,230,118,0.35);
+}
+
+.line {
+  width: min(18vw, 200px);
+  height: 2px;
+  background-image: repeating-linear-gradient(
+    to right,
+    rgba(255,255,255,0.6) 0 10px,
+    rgba(255,255,255,0.1) 10px 16px
+  );
+  filter: drop-shadow(0 0 2px rgba(255,255,255,0.35));
+}
+
+.left .connector { justify-content: flex-start; }
+.right .connector { justify-content: flex-end; }
+
+@media (prefers-reduced-motion: reduce) {
+  .card,
+  .segment { transition: none !important; }
+  .card:hover, .card:focus, .card:active { transform: none !important; }
+}
+

--- a/src/components/about/ParcoursTimeline.tsx
+++ b/src/components/about/ParcoursTimeline.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useMemo, useRef } from "react";
+import styles from "./ParcoursTimeline.module.css";
+
+type Step = {
+  id: number;
+  side: "left" | "right";
+  title: string;
+  subtitle: string;
+  period: string;
+  bullets: string[];
+};
+
+const stepsData: Step[] = [
+  {
+    id: 1,
+    side: "right",
+    title: "Baccalauréat Technologique (STI2D)",
+    subtitle: "Option SIN",
+    period: "2018–2020",
+    bullets: ["Mention Bien", "Projet domotique open-source"],
+  },
+  {
+    id: 2,
+    side: "left",
+    title: "Développeur Alternant",
+    subtitle: "ACME Corp • Next.js & Node.js",
+    period: "2020–2022",
+    bullets: ["-20% temps de build CI", "+15% couverture de tests"],
+  },
+  {
+    id: 3,
+    side: "right",
+    title: "Projet SR13 • Automatisation IA",
+    subtitle: "SaaS multi-tenant • TPE/PME",
+    period: "2023–2024",
+    bullets: ["Onboarding auto &lt;5 min", "Workflow doc scanning ×3"],
+  },
+  {
+    id: 4,
+    side: "left",
+    title: "Aujourd’hui",
+    subtitle: "Ingénierie data / Full‑stack",
+    period: "2024–",
+    bullets: ["Back/Front/Mobile", "Perf & UX"],
+  },
+];
+
+export default function ParcoursTimeline({ steps = stepsData }: { steps?: Step[] }) {
+  const railRef = useRef<HTMLDivElement | null>(null);
+  const segmentsRef = useRef<HTMLSpanElement[]>([]);
+  segmentsRef.current = [];
+
+  const segmentsCount = 28;
+  const segments = useMemo(() => Array.from({ length: segmentsCount }), [segmentsCount]);
+
+  const addSegmentRef = (el: HTMLSpanElement | null) => {
+    if (el && !segmentsRef.current.includes(el)) segmentsRef.current.push(el);
+  };
+
+  useEffect(() => {
+    const handler = () => {
+      const centerY = window.innerHeight / 2;
+      segmentsRef.current.forEach((seg) => {
+        const rect = seg.getBoundingClientRect();
+        const segCenter = rect.top + rect.height / 2;
+        const dist = Math.abs(segCenter - centerY);
+        const intensity = Math.max(0, 1 - dist / (window.innerHeight * 0.6));
+        seg.style.setProperty("--glow", intensity.toFixed(3));
+      });
+    };
+
+    handler();
+    window.addEventListener("scroll", handler, { passive: true });
+    window.addEventListener("resize", handler);
+    return () => {
+      window.removeEventListener("scroll", handler);
+      window.removeEventListener("resize", handler);
+    };
+  }, []);
+
+  return (
+    <section className={styles.wrapper} aria-label="Parcours">
+      <div className={styles.rail} ref={railRef}>
+        {segments.map((_, i) => (
+          <span key={i} ref={addSegmentRef} className={styles.segment} aria-hidden="true" />
+        ))}
+      </div>
+
+      <ol className={styles.zigzag}>
+        {steps.map((s, i) => (
+          <li
+            key={s.id}
+            className={`${styles.item} ${s.side === "left" ? styles.left : styles.right}`}
+            style={{ "--i": String(i) } as React.CSSProperties}
+          >
+            <article className={styles.card} tabIndex={0}>
+              <header className={styles.cardHeader}>
+                <h3 className={styles.title}>{s.title}</h3>
+                <p className={styles.subtitle}>{s.subtitle}</p>
+                <time className={styles.period}>{s.period}</time>
+              </header>
+              <ul className={styles.bullets}>
+                {s.bullets.map((b, j) => (
+                  <li key={j}>{b}</li>
+                ))}
+              </ul>
+              <div className={styles.cornerTag} aria-hidden="true">
+                #{String(s.id).padStart(2, "0")}
+              </div>
+            </article>
+
+            <div className={styles.connector} aria-hidden="true">
+              <span className={styles.dot} />
+              <span className={styles.line} />
+            </div>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add dynamic about page with full-stack profile intro
- implement ParcoursTimeline component with scroll glow and 3D hover cards
- style timeline via CSS modules for segmented rail and zigzag layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in src/components/dna/background/KaizenHalo.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e600b5d4832e813969d524eeb5fe