### PR TITLE
Fix Parcours timeline alignment and scroll effects

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -579,27 +579,26 @@ img {
   padding: 0;
   position: relative;
   z-index: 1;
-}
-
-.item {
-  position: relative;
   display: grid;
   grid-template-columns: 1fr;
-  align-items: center;
-  margin: 6rem 0;
+  gap: 6rem;
 }
 
 @media (min-width: 800px) {
-  .item {
+  .zigzag {
     grid-template-columns: 1fr 1fr;
   }
 }
 
-.left  { grid-template-areas: "card ."; }
-.right { grid-template-areas: ". card"; }
+.item {
+  position: relative;
+  display: contents;
+}
+
+.left > .card { grid-column: 1; }
+.right > .card { grid-column: 2; }
 
 .card {
-  grid-area: card;
   background: linear-gradient(180deg, var(--bg), transparent 140%),
               linear-gradient(to right, rgba(255,255,255,0.08), rgba(255,255,255,0.03));
   border: 1px solid var(--stroke);
@@ -652,14 +651,21 @@ img {
 }
 
 .connector {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%,-50%);
+  position: relative;
+  height: 0;
   display: flex;
   align-items: center;
-  gap: 12px;
   pointer-events: none;
+}
+
+.left > .connector {
+  grid-column: 2;
+  justify-self: end;
+}
+
+.right > .connector {
+  grid-column: 1;
+  justify-self: start;
 }
 
 .dot {
@@ -671,18 +677,19 @@ img {
 }
 
 .line {
+  display: inline-block;
+  margin: 0 12px;
   width: min(18vw, 200px);
   height: 2px;
   background-image: repeating-linear-gradient(
     to right,
-    rgba(255,255,255,0.6) 0 10px,
-    rgba(255,255,255,0.1) 10px 16px
+    rgba(255,255,255, calc(0.4 + var(--charge, 0) * 0.6)) 0 10px,
+    rgba(255,255,255,0.08) 10px 16px
   );
+  opacity: calc(0.4 + var(--charge, 0) * 0.6);
   filter: drop-shadow(0 0 2px rgba(255,255,255,0.35));
+  transition: opacity 120ms linear, filter 120ms linear;
 }
-
-.left .connector { justify-content: flex-start; }
-.right .connector { justify-content: flex-end; }
 
 @media (prefers-reduced-motion: reduce) {
   .card,

--- a/src/ui/components/portfolio/sections/ParcoursTimeline.tsx
+++ b/src/ui/components/portfolio/sections/ParcoursTimeline.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef } from "react";
 
 type Step = {
   id: number;
-  side: "left" | "right";
+  side?: "left" | "right";
   title: string;
   subtitle: string;
   period: string;
@@ -45,15 +45,19 @@ const stepsData: Step[] = [
 ];
 
 export default function ParcoursTimeline({ steps = stepsData }: { steps?: Step[] }) {
-  const railRef = useRef<HTMLDivElement | null>(null);
   const segmentsRef = useRef<HTMLSpanElement[]>([]);
   segmentsRef.current = [];
+  const cardsRef = useRef<HTMLDivElement[]>([]);
+  cardsRef.current = [];
 
   const segmentsCount = 28;
   const segments = useMemo(() => Array.from({ length: segmentsCount }), [segmentsCount]);
 
   const addSegmentRef = (el: HTMLSpanElement | null) => {
     if (el && !segmentsRef.current.includes(el)) segmentsRef.current.push(el);
+  };
+  const addCardRef = (el: HTMLDivElement | null) => {
+    if (el && !cardsRef.current.includes(el)) cardsRef.current.push(el);
   };
 
   useEffect(() => {
@@ -66,7 +70,17 @@ export default function ParcoursTimeline({ steps = stepsData }: { steps?: Step[]
         const intensity = Math.max(0, 1 - dist / (window.innerHeight * 0.6));
         seg.style.setProperty("--glow", intensity.toFixed(3));
       });
+      cardsRef.current.forEach((card) => {
+        const rect = card.getBoundingClientRect();
+        const cardCenter = rect.top + rect.height / 2;
+        const dist = Math.abs(cardCenter - centerY);
+        const t = Math.max(0, 1 - dist / (window.innerHeight * 0.7));
+        card.parentElement?.style.setProperty("--charge", t.toFixed(3));
+      });
     };
+
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    if (mq.matches) return;
 
     handler();
     window.addEventListener("scroll", handler, { passive: true });
@@ -79,41 +93,38 @@ export default function ParcoursTimeline({ steps = stepsData }: { steps?: Step[]
 
   return (
     <section id="about" className="wrapper" aria-label="Parcours">
-      <div className="rail" ref={railRef}>
+      <div className="rail">
         {segments.map((_, i) => (
           <span key={i} ref={addSegmentRef} className="segment" aria-hidden="true" />
         ))}
       </div>
 
       <ol className="zigzag">
-        {steps.map((s, i) => (
-          <li
-            key={s.id}
-            className={`${"item"} ${s.side === "left" ? "left" : "right"}`}
-            style={{ "--i": String(i) } as React.CSSProperties}
-          >
-            <article className="card" tabIndex={0}>
-              <header className="cardHeader">
-                <h3 className="title">{s.title}</h3>
-                <p className="subtitle">{s.subtitle}</p>
-                <time className="period">{s.period}</time>
-              </header>
-              <ul className="bullets">
-                {s.bullets.map((b, j) => (
-                  <li key={j}>{b}</li>
-                ))}
-              </ul>
-              <div className="cornerTag" aria-hidden="true">
-                #{String(s.id).padStart(2, "0")}
+        {steps
+          .map((s, i) => ({ ...s, side: s.side ?? (i % 2 ? "left" : "right") }))
+          .map((s) => (
+            <li key={s.id} className={`item ${s.side === "left" ? "left" : "right"}`}>
+              <article ref={addCardRef} className="card" tabIndex={0}>
+                <header className="cardHeader">
+                  <h3 className="title">{s.title}</h3>
+                  <p className="subtitle">{s.subtitle}</p>
+                  <time className="period">{s.period}</time>
+                </header>
+                <ul className="bullets">
+                  {s.bullets.map((b, j) => (
+                    <li key={j}>{b}</li>
+                  ))}
+                </ul>
+                <div className="cornerTag" aria-hidden="true">
+                  #{String(s.id).padStart(2, "0")}
+                </div>
+              </article>
+              <div className="connector" aria-hidden="true">
+                <span className="dot" />
+                <span className="line" />
               </div>
-            </article>
-
-            <div className="connector" aria-hidden="true">
-              <span className="dot" />
-              <span className="line" />
-            </div>
-          </li>
-        ))}
+            </li>
+          ))}
       </ol>
     </section>
   );


### PR DESCRIPTION
## Summary
- alternate timeline cards left/right on a central rail
- add connector dash with scroll-based glow
- respect prefers-reduced-motion and clean up styles

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a71fd438f0832e9ca198d191d4c520