### PR TITLE
Animate timeline dots and add cursor push to project cards

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -674,6 +674,37 @@ img {
   border-radius: 999px;
   background: var(--accent);
   box-shadow: 0 0 10px var(--accent), 0 0 30px rgba(0,230,118,0.35);
+  position: relative;
+  animation: particle-float 6s ease-in-out infinite;
+}
+
+.dot::before {
+  content: "";
+  position: absolute;
+  inset: -12px;
+  background: var(--accent);
+  opacity: 0.25;
+  border-radius: 999px;
+  filter: blur(20px);
+  z-index: -1;
+}
+
+@keyframes particle-float {
+  0% {
+    transform: translate(0, 0);
+  }
+  25% {
+    transform: translate(2px, -4px);
+  }
+  50% {
+    transform: translate(-2px, -8px);
+  }
+  75% {
+    transform: translate(2px, -4px);
+  }
+  100% {
+    transform: translate(0, 0);
+  }
 }
 
 .line {

--- a/src/ui/components/dna/card/Card.tsx
+++ b/src/ui/components/dna/card/Card.tsx
@@ -1,13 +1,18 @@
-import { HTMLAttributes } from "react";
+import { HTMLAttributes, forwardRef } from "react";
 
 export type CardProps = HTMLAttributes<HTMLDivElement>;
 
-export default function Card({ className = "", ...props }: CardProps) {
-  return (
+const Card = forwardRef<HTMLDivElement, CardProps>(
+  ({ className = "", ...props }, ref) => (
     <div
-      className={`rounded-xl bg-white/60 backdrop-blur-md border border-white/20 shadow-md p-6 md:p-8 ${className}`}
+      ref={ref}
+      className={`rounded-xl bg-white/60 backdrop-blur-md border border-white/20 shadow-md p-6 md:p-8 transition-transform duration-150 ${className}`}
       {...props}
     />
-  );
-}
+  )
+);
+
+Card.displayName = "Card";
+
+export default Card;
 

--- a/src/ui/components/portfolio/cards/ProjectCard.tsx
+++ b/src/ui/components/portfolio/cards/ProjectCard.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
+import { useEffect, useRef } from "react";
 import { Card } from "@ui/components/dna/card";
 import { Heading, Text } from "@ui/components/dna/typography";
 import { Button } from "@ui/components/dna/button";
@@ -21,8 +22,39 @@ export default function ProjectCard({
   image,
   href,
 }: ProjectCardProps) {
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    if (mq.matches) return;
+
+    const handlePointerMove = (e: PointerEvent) => {
+      const card = cardRef.current;
+      if (!card) return;
+      const rect = card.getBoundingClientRect();
+      const centerX = rect.left + rect.width / 2;
+      const centerY = rect.top + rect.height / 2;
+      const dx = centerX - e.clientX;
+      const dy = centerY - e.clientY;
+      const distance = Math.hypot(dx, dy);
+      const hoverRadius = 160;
+      if (distance < hoverRadius) {
+        const strength = ((hoverRadius - distance) / hoverRadius) * 30;
+        const angle = Math.atan2(dy, dx);
+        const tx = Math.cos(angle) * strength;
+        const ty = Math.sin(angle) * strength;
+        card.style.transform = `translate(${tx}px, ${ty}px)`;
+      } else {
+        card.style.transform = "";
+      }
+    };
+
+    window.addEventListener("pointermove", handlePointerMove);
+    return () => window.removeEventListener("pointermove", handlePointerMove);
+  }, []);
+
   return (
-    <Card className="flex h-full flex-col">
+    <Card ref={cardRef} className="flex h-full flex-col">
       <div className="mb-4 overflow-hidden rounded-lg shadow">
         <Image
           src={image}


### PR DESCRIPTION
## Summary
- add floating glow and particle motion to timeline connector dots
- forward ref-enabled card component with transform transitions
- push project cards away from the cursor using pointer tracking

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a77cf92a28832e8c5e068498497263