### PR TITLE
feat: scale timeline segments

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -570,7 +570,9 @@ img {
   opacity: calc(0.18 + var(--glow, 0) * 0.72);
   filter: blur(calc(1px + var(--glow, 0) * 1.5px));
   border-radius: 2px;
-  transition: opacity 120ms linear, filter 120ms linear;
+  transform: scale(var(--scale, 1));
+  transform-origin: center;
+  transition: opacity 120ms linear, filter 120ms linear, transform 120ms linear;
 }
 
 .zigzag {

--- a/src/ui/components/portfolio/sections/ParcoursTimeline.tsx
+++ b/src/ui/components/portfolio/sections/ParcoursTimeline.tsx
@@ -74,7 +74,9 @@ export default function ParcoursTimeline({ steps = stepsData }: { steps?: Step[]
         const segCenter = rect.top + rect.height / 2;
         const dist = Math.abs(segCenter - centerY);
         const intensity = Math.max(0, 1 - dist / (window.innerHeight * 0.6));
+        const scale = 1 + intensity * 0.5;
         seg.style.setProperty("--glow", intensity.toFixed(3));
+        seg.style.setProperty("--scale", scale.toFixed(3));
       });
       cardsRef.current.forEach((card) => {
         const rect = card.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- compute `--scale` variable for timeline segments based on scroll position
- animate segment scaling via CSS `transform` and transitions

## Testing
- `npm test`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a7837caef4832e83702909c7ef1dcf