### PR TITLE
fix: ensure Parcours timeline fits on mobile

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -575,7 +575,7 @@ img {
   transition: opacity 120ms linear, filter 120ms linear, transform 120ms linear;
 }
 
-.zigzag {
+ .zigzag {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -586,20 +586,10 @@ img {
   gap: 6rem;
 }
 
-@media (min-width: 800px) {
-  .zigzag {
-    grid-template-columns: 1fr 1fr;
-  }
-}
-
 .item {
   position: relative;
   display: contents;
 }
-
-.left > .card { grid-column: 1; }
-.right > .card { grid-column: 2; }
-
 .card {
   background: linear-gradient(180deg, var(--bg), transparent 140%),
               linear-gradient(to right, rgba(255,255,255,0.08), rgba(255,255,255,0.03));
@@ -660,14 +650,28 @@ img {
   pointer-events: none;
 }
 
-.left > .connector {
-  grid-column: 2;
-  justify-self: end;
+.left > .connector,
+.right > .connector {
+  justify-self: center;
 }
 
-.right > .connector {
-  grid-column: 1;
-  justify-self: start;
+@media (min-width: 800px) {
+  .zigzag {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .left > .card { grid-column: 1; }
+  .right > .card { grid-column: 2; }
+
+  .left > .connector {
+    grid-column: 2;
+    justify-self: end;
+  }
+
+  .right > .connector {
+    grid-column: 1;
+    justify-self: start;
+  }
 }
 
 .dot {


### PR DESCRIPTION
## Summary
- center timeline connectors on small screens
- apply zigzag grid placement only on wide screens

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a82574fad0832e996e8b9b0cc485f2