### PR TITLE
feat: add animated kaizen landing with modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "@ai-sdk/react": "^1.2.12",
                 "ai": "^4.3.16",
                 "autoprefixer": "^10.4.21",
+                "framer-motion": "^11.18.2",
                 "next": "15.3.3",
                 "react": "^19.0.0",
                 "react-dom": "^19.0.0",
@@ -3717,6 +3718,33 @@
                 "url": "https://github.com/sponsors/rawify"
             }
         },
+        "node_modules/framer-motion": {
+            "version": "11.18.2",
+            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+            "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+            "license": "MIT",
+            "dependencies": {
+                "motion-dom": "^11.18.1",
+                "motion-utils": "^11.18.1",
+                "tslib": "^2.4.0"
+            },
+            "peerDependencies": {
+                "@emotion/is-prop-valid": "*",
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/is-prop-valid": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                },
+                "react-dom": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/function-bind": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -5741,6 +5769,21 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/motion-dom": {
+            "version": "11.18.1",
+            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+            "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+            "license": "MIT",
+            "dependencies": {
+                "motion-utils": "^11.18.1"
+            }
+        },
+        "node_modules/motion-utils": {
+            "version": "11.18.1",
+            "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+            "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+            "license": "MIT"
+        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -7661,7 +7704,6 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
             "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "@ai-sdk/react": "^1.2.12",
         "ai": "^4.3.16",
         "autoprefixer": "^10.4.21",
+        "framer-motion": "^11.18.2",
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",

--- a/src/app/kaizen/introduction/page.tsx
+++ b/src/app/kaizen/introduction/page.tsx
@@ -1,22 +1,17 @@
-import Link from 'next/link';
+'use client';
+
+import { useState } from 'react';
+import Intro from '@/ui/components/kaizen/Intro';
+import KaizenModal from '@/ui/components/kaizen/KaizenModal';
 
 export default function KaizenIntroductionPage() {
+  const [open, setOpen] = useState(false);
+
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center text-center px-4 overflow-hidden relative">
-      <h1 className="text-4xl sm:text-6xl font-bold mb-4 animate-[fade-in-up_0.6s_ease-out_forwards]">
-        Kaizen Learning
-      </h1>
-      <p
-        className="max-w-md mb-8 text-lg sm:text-xl opacity-80 animate-[fade-in-up_0.6s_ease-out_forwards] [animation-delay:0.2s]"
-      >
-        Continuous improvement through short lessons and quick exercises.
-      </p>
-      <Link
-        href="/kaizen/guest"
-        className="btn-glass px-6 py-3 rounded-xl animate-[fade-in-up_0.6s_ease-out_forwards] [animation-delay:0.4s]"
-      >
-        Try as Guest
-      </Link>
-    </div>
+    <>
+      <Intro onStart={() => setOpen(true)} />
+      <KaizenModal open={open} onClose={() => setOpen(false)} />
+    </>
   );
 }
+

--- a/src/ui/components/kaizen/Intro.tsx
+++ b/src/ui/components/kaizen/Intro.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { motion, useScroll, useTransform } from 'framer-motion';
+import React from 'react';
+import SideSvg from './SideSvg';
+
+interface IntroProps {
+  onStart: () => void;
+}
+
+export default function Intro({ onStart }: IntroProps) {
+  const { scrollYProgress } = useScroll();
+  const leftX = useTransform(scrollYProgress, [0, 1], ['-100%', '0%']);
+  const rightX = useTransform(scrollYProgress, [0, 1], ['100%', '0%']);
+  const color = useTransform(scrollYProgress, [0.8, 1], ['#4b5563', '#4ade80']);
+  const glow = useTransform(
+    scrollYProgress,
+    [0.8, 1],
+    ['drop-shadow(0 0 0px #4ade80)', 'drop-shadow(0 0 12px #4ade80)']
+  );
+  const bgY = useTransform(scrollYProgress, [0, 1], ['0%', '20%']);
+
+  return (
+    <section
+      className="relative flex min-h-screen items-center justify-center overflow-hidden bg-gradient-to-b from-gray-900 to-black bg-[length:100%_150%] text-white"
+      style={{ backgroundPositionY: bgY }}
+    >
+      <SideSvg style={{ x: leftX, color, filter: glow }} />
+      <SideSvg mirrored style={{ x: rightX, color, filter: glow }} />
+      <div className="px-4 text-center">
+        <motion.h1
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          className="mb-6 text-4xl font-bold sm:text-6xl"
+        >
+          Kaizen Learning
+        </motion.h1>
+        <motion.p
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.2, duration: 0.6 }}
+          className="mb-8 text-lg text-white/80 sm:text-2xl"
+        >
+          Learn faster and better with AI guidance.
+        </motion.p>
+        <motion.button
+          onClick={onStart}
+          whileHover={{ scale: 1.05 }}
+          whileTap={{ scale: 0.97 }}
+          className="rounded-xl border border-green-400/50 bg-green-500/20 px-8 py-3 font-medium text-green-300 shadow-[0_0_15px_#22c55e44] transition-colors hover:bg-green-500/30 hover:shadow-[0_0_25px_#22c55eaa]"
+        >
+          Start Learning
+        </motion.button>
+      </div>
+    </section>
+  );
+}
+

--- a/src/ui/components/kaizen/KaizenModal.tsx
+++ b/src/ui/components/kaizen/KaizenModal.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { motion, AnimatePresence } from 'framer-motion';
+import Link from 'next/link';
+import React from 'react';
+
+interface KaizenModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function KaizenModal({ open, onClose }: KaizenModalProps) {
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+          onClick={onClose}
+        >
+          <motion.div
+            initial={{ scale: 0.8, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.8, opacity: 0 }}
+            transition={{ type: 'spring', stiffness: 300, damping: 25 }}
+            className="relative w-full max-w-sm rounded-2xl border border-white/20 bg-white/10 p-8 text-white backdrop-blur-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="mb-6 text-2xl font-semibold">Welcome</h2>
+            <form className="space-y-4">
+              <input
+                type="email"
+                placeholder="Email"
+                className="w-full rounded bg-white/5 p-2 placeholder-white/50 focus:outline-none"
+              />
+              <input
+                type="password"
+                placeholder="Password"
+                className="w-full rounded bg-white/5 p-2 placeholder-white/50 focus:outline-none"
+              />
+              <button
+                type="submit"
+                className="w-full rounded bg-green-500/20 py-2 text-green-300 transition hover:bg-green-500/30"
+              >
+                Login
+              </button>
+            </form>
+            <div className="mt-6">
+              <Link
+                href="/kaizen/guest"
+                className="block w-full rounded bg-green-500 py-2 text-center font-medium text-black transition hover:bg-green-400"
+                onClick={onClose}
+              >
+                Guest Test
+              </Link>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+

--- a/src/ui/components/kaizen/SideSvg.tsx
+++ b/src/ui/components/kaizen/SideSvg.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { motion, MotionStyle } from 'framer-motion';
+import React from 'react';
+
+interface SideSvgProps {
+  mirrored?: boolean;
+  style?: MotionStyle;
+}
+
+export default function SideSvg({ mirrored = false, style }: SideSvgProps) {
+  return (
+    <motion.svg
+      viewBox="0 0 100 400"
+      className={`pointer-events-none absolute top-0 h-full w-24 text-gray-600 ${
+        mirrored ? 'right-0' : 'left-0'
+      }`}
+      style={style}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M20 0 V400 M50 0 V400 M80 0 V400"
+        stroke="currentColor"
+        strokeWidth="2"
+      />
+      <circle cx="20" cy="80" r="6" fill="currentColor" />
+      <circle cx="50" cy="200" r="6" fill="currentColor" />
+      <circle cx="80" cy="320" r="6" fill="currentColor" />
+    </motion.svg>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add scroll-animated hero with mirrored SVG circuitry and glow effect
- include start-learning modal with login form and guest access
- install framer-motion for motion and scroll animations

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a834998304832e8aa26294d7b26177