### PR TITLE
feat: integrate Kaizen landing page into introduction route

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kaizen Learning</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  </head>
+  <body class="bg-gray-950">
+    <div id="root"></div>
+  </body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,23 +1,23 @@
 'use client';
 
 import { useState } from 'react';
-import { defaultContent } from '@/content/defaultContent';
-import Header from '@/ui/components/kaizen/Header';
-import Hero from '@/ui/components/kaizen/Hero';
-import HowItWorks from '@/ui/components/kaizen/HowItWorks';
-import Benefits from '@/ui/components/kaizen/Benefits';
-import Features from '@/ui/components/kaizen/Features';
-import Pricing from '@/ui/components/kaizen/Pricing';
-import SecurityPrivacy from '@/ui/components/kaizen/SecurityPrivacy';
-import Demo from '@/ui/components/kaizen/Demo';
-import Testimonials from '@/ui/components/kaizen/Testimonials';
-import FAQ from '@/ui/components/kaizen/FAQ';
-import Roadmap from '@/ui/components/kaizen/Roadmap';
-import FinalCTA from '@/ui/components/kaizen/FinalCTA';
-import Footer from '@/ui/components/kaizen/Footer';
-import AuthModal from '@/ui/components/kaizen/AuthModal';
+import { defaultContent } from './content/defaultContent';
+import Header from './ui/components/kaizen/Header';
+import Hero from './ui/components/kaizen/Hero';
+import HowItWorks from './ui/components/kaizen/HowItWorks';
+import Benefits from './ui/components/kaizen/Benefits';
+import Features from './ui/components/kaizen/Features';
+import Pricing from './ui/components/kaizen/Pricing';
+import SecurityPrivacy from './ui/components/kaizen/SecurityPrivacy';
+import Demo from './ui/components/kaizen/Demo';
+import Testimonials from './ui/components/kaizen/Testimonials';
+import FAQ from './ui/components/kaizen/FAQ';
+import Roadmap from './ui/components/kaizen/Roadmap';
+import FinalCTA from './ui/components/kaizen/FinalCTA';
+import Footer from './ui/components/kaizen/Footer';
+import AuthModal from './ui/components/kaizen/AuthModal';
 
-export default function KaizenIntroductionPage() {
+export default function App() {
   const [modalOpen, setModalOpen] = useState(false);
   const navItems = [
     { id: 'intro', label: 'Intro' },

--- a/src/content/defaultContent.ts
+++ b/src/content/defaultContent.ts
@@ -1,0 +1,192 @@
+export const defaultContent = {
+  hero: {
+    title: 'Kaizen Learning',
+    subtitle: 'Learn faster and better with AI-guided lessons.',
+    bullets: [
+      'Generate tailored lessons in seconds.',
+      'Adaptive difficulty from your progress.',
+      'Actionable practice, not fluff.',
+    ],
+    primaryCta: 'Start',
+    secondaryCta: 'See how it works',
+  },
+  howItWorks: [
+    {
+      title: 'Tell us your goal',
+      text: 'Pick a topic, level, and deadline.',
+    },
+    {
+      title: 'AI composes your path',
+      text: 'We plan lessons + practice with spaced repetition.',
+    },
+    {
+      title: 'You learn with feedback',
+      text: 'Hints, checkpoints, and micro-quizzes adapt to you.',
+    },
+  ],
+  benefits: {
+    paragraph:
+      'Traditional study wastes cycles on planning and searching. Kaizen focuses attention on high-yield tasks—sequenced, time-boxed, and explained when it matters.',
+    items: [
+      'Personalized difficulty curve',
+      'Immediate, targeted feedback',
+      'Built-in retention (spaced repetition)',
+      'Fast lesson generation (seconds, not hours)',
+      'Progress you can feel (metrics that matter)',
+    ],
+  },
+  features: [
+    {
+      title: 'Lesson Generator',
+      text: 'From a topic or syllabus, get a structured lesson with explanations, examples, and practice.',
+    },
+    {
+      title: 'Adaptive Practice',
+      text: 'Quizzes and tasks adapt in real time based on your mastery.',
+    },
+    {
+      title: 'Project Mode',
+      text: 'Turn goals into step-by-step plans with milestones.',
+    },
+    {
+      title: 'Knowledge Map',
+      text: 'See concept dependencies; fill gaps with targeted drills.',
+    },
+    {
+      title: 'Export & Share',
+      text: 'Export lessons to PDF/Markdown; share with teammates.',
+    },
+    {
+      title: 'Integrations',
+      text: '(Placeholder) Google Drive, Notion, LMS (coming soon).',
+    },
+  ],
+  pricing: {
+    tiers: [
+      {
+        name: 'Guest',
+        priceText: 'Free',
+        features: [
+          'Limited lesson generation (3/day)',
+          'No exports',
+          'Basic analytics',
+        ],
+        cta: 'Start as Guest',
+      },
+      {
+        name: 'Pro',
+        priceText: '$9/mo',
+        features: [
+          'Higher generation quota',
+          'Exports',
+          'Spaced repetition scheduling',
+          'Priority compute',
+        ],
+        cta: 'Go Pro',
+      },
+      {
+        name: 'Team',
+        priceText: '$29/user/mo',
+        features: [
+          'Seat-based pricing',
+          'Shared libraries',
+          'Admin analytics',
+          'SSO (coming soon)',
+        ],
+        cta: 'Contact Sales',
+      },
+    ],
+    note: 'Fair Use applies. Cancel anytime.',
+  },
+  security: {
+    bullets: [
+      'We store your lessons and progress to personalize your experience.',
+      'You control your data: export and delete in one click.',
+      'Transport encrypted (TLS). Data at rest encrypted on server.',
+      'Minimal PII; email required for account. No sale of data.',
+      'EU-friendly: supports GDPR rights (access, rectification, deletion).',
+    ],
+    miniFaq: [
+      {
+        q: 'Do you train on my private data?',
+        a: 'No, content is isolated for your account; aggregate telemetry is anonymized for system quality.',
+      },
+    ],
+  },
+  demo: {
+    title: 'Live Demo',
+    subtitle: 'Safe placeholder',
+    leftMockJson: '{\n  "goal": "Learn algebra",\n  "outline": ["Variables", "Equations"],\n  "lesson": "..."\n}',
+    guestNote: 'Guest mode is rate-limited. Sign in for full features.',
+  },
+  testimonials: [
+    {
+      quote: 'Felt like having a coach in the page.',
+      name: 'Alex P.',
+      role: 'Student',
+    },
+    {
+      quote: 'Cut my prep time in half.',
+      name: 'Jamie L.',
+      role: 'Teacher',
+    },
+    {
+      quote: 'The adaptive drills are gold.',
+      name: 'Casey R.',
+      role: 'Engineer',
+    },
+  ],
+  faq: [
+    {
+      q: 'What makes Kaizen different from generic chatbots?',
+      a: 'It plans structured lessons and adapts to your performance.',
+    },
+    {
+      q: 'Can I import my syllabus?',
+      a: 'Yes, syllabus import is supported.',
+    },
+    {
+      q: 'Does it work offline?',
+      a: 'Core features require connectivity.',
+    },
+    {
+      q: 'Do you support STEM and humanities?',
+      a: 'Both, with subject-aware guidance.',
+    },
+    {
+      q: 'What’s the refund policy?',
+      a: 'Pro plans can be cancelled anytime with a prorated refund.',
+    },
+    {
+      q: 'How are lessons evaluated?',
+      a: 'We use checkpoints and mastery metrics.',
+    },
+  ],
+  roadmap: [
+    {
+      title: 'Lesson v1',
+      eta: 'Q1',
+      text: 'Initial lesson generator release.',
+    },
+    {
+      title: 'Adaptive Practice v2',
+      eta: 'Q2',
+      text: 'Richer quizzes and difficulty shaping.',
+    },
+    {
+      title: 'Integrations',
+      eta: 'Q3',
+      text: 'Google Drive, Notion, LMS.',
+    },
+    {
+      title: 'Team Admin & SSO',
+      eta: 'Q4',
+      text: 'Enterprise controls and single sign-on.',
+    },
+  ],
+  finalCta: {
+    primary: 'Start free as Guest',
+    secondary: 'Book a demo',
+    note: 'Building for schools and teams? Let’s talk.',
+  },
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,12 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --glass-bg: rgba(255,255,255,0.05);
+  --accent: #4ade80;
+}
+
+body {
+  @apply bg-black text-white font-sans;
+}

--- a/src/ui/components/kaizen/AuthModal.tsx
+++ b/src/ui/components/kaizen/AuthModal.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { motion, AnimatePresence } from 'framer-motion';
+import { useState } from 'react';
+
+interface AuthModalProps {
+  open: boolean;
+  onClose: () => void;
+  initialTab?: 'login' | 'guest';
+}
+
+export default function AuthModal({ open, onClose, initialTab = 'login' }: AuthModalProps) {
+  const [tab, setTab] = useState(initialTab);
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          <motion.div
+            initial={{ scale: 0.9, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.9, opacity: 0 }}
+            className="w-full max-w-md rounded-2xl border border-white/10 bg-white/5 p-6 text-white shadow-xl backdrop-blur-xl"
+          >
+            <div className="mb-4 flex justify-between">
+              <button
+                className={`flex-1 border-b pb-2 ${tab === 'login' ? 'border-green-400 text-green-400' : 'border-transparent'}`}
+                onClick={() => setTab('login')}
+              >
+                Login
+              </button>
+              <button
+                className={`flex-1 border-b pb-2 ${tab === 'guest' ? 'border-green-400 text-green-400' : 'border-transparent'}`}
+                onClick={() => setTab('guest')}
+              >
+                Guest
+              </button>
+            </div>
+            {tab === 'login' ? (
+              <div className="space-y-4">
+                <input
+                  type="email"
+                  placeholder="Email"
+                  className="w-full rounded-md bg-black/40 p-2 text-sm focus:outline-none focus:ring-1 focus:ring-green-400/40"
+                />
+                <input
+                  type="password"
+                  placeholder="Password"
+                  className="w-full rounded-md bg-black/40 p-2 text-sm focus:outline-none focus:ring-1 focus:ring-green-400/40"
+                />
+                <button
+                  onClick={() => console.log('login')}
+                  className="w-full rounded-md bg-green-500/20 py-2 text-green-300 hover:bg-green-500/30"
+                >
+                  Continue
+                </button>
+                <a href="#" className="block text-center text-xs text-white/60">
+                  Forgot password?
+                </a>
+              </div>
+            ) : (
+              <div className="space-y-4 text-sm">
+                <p>Continue as guest with limited quota.</p>
+                <button
+                  onClick={() => console.log('startGuestTrial')}
+                  className="w-full rounded-md bg-green-500/20 py-2 text-green-300 hover:bg-green-500/30"
+                >
+                  Continue as Guest
+                </button>
+                <p className="text-xs text-white/60">Quota applies to guest sessions.</p>
+              </div>
+            )}
+            <button
+              onClick={onClose}
+              className="mt-6 block w-full rounded-md bg-white/10 py-2 text-sm hover:bg-white/20"
+            >
+              Close
+            </button>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/ui/components/kaizen/Benefits.tsx
+++ b/src/ui/components/kaizen/Benefits.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import Container from './Container';
+
+interface BenefitsProps {
+  content: {
+    paragraph: string;
+    items: string[];
+  };
+}
+
+export default function Benefits({ content }: BenefitsProps) {
+  return (
+    <section id="benefits" className="py-24">
+      <Container>
+        <div className="grid items-start gap-8 md:grid-cols-2">
+          <motion.p
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, ease: 'easeOut' }}
+            className="text-white/80"
+          >
+            {content.paragraph}
+          </motion.p>
+          <ul className="space-y-3">
+            {content.items.map((item) => (
+              <motion.li
+                key={item}
+                initial={{ opacity: 0, x: -10 }}
+                whileInView={{ opacity: 1, x: 0 }}
+                transition={{ duration: 0.4, ease: 'easeOut' }}
+                className="flex items-center gap-2"
+              >
+                <svg
+                  className="h-4 w-4 text-green-400"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M16.704 5.29a1 1 0 010 1.414l-7.071 7.072a1 1 0 01-1.414 0L3.296 8.853a1 1 0 111.414-1.414l4.095 4.096 6.364-6.364a1 1 0 011.414 0z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+                <span>{item}</span>
+              </motion.li>
+            ))}
+          </ul>
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/src/ui/components/kaizen/Container.tsx
+++ b/src/ui/components/kaizen/Container.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+export default function Container({ children }: Props) {
+  return <div className="mx-auto w-full max-w-6xl px-4">{children}</div>;
+}

--- a/src/ui/components/kaizen/Demo.tsx
+++ b/src/ui/components/kaizen/Demo.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import Container from './Container';
+
+interface DemoContent {
+  title: string;
+  subtitle: string;
+  leftMockJson: string;
+  guestNote: string;
+}
+
+interface DemoProps {
+  content: DemoContent;
+  onGuest: () => void;
+}
+
+export default function Demo({ content, onGuest }: DemoProps) {
+  return (
+    <section id="demo" className="py-24">
+      <Container>
+        <h2 className="mb-8 text-center text-2xl font-semibold">{content.title}</h2>
+        <p className="mb-8 text-center text-white/70">{content.subtitle}</p>
+        <div className="grid gap-8 md:grid-cols-2">
+          <motion.pre
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, ease: 'easeOut' }}
+            className="overflow-auto rounded-2xl border border-white/10 bg-white/5 p-4 text-sm backdrop-blur-xl"
+          >
+            <code>{content.leftMockJson}</code>
+          </motion.pre>
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.1, ease: 'easeOut' }}
+            className="flex flex-col items-center justify-center rounded-2xl border border-white/10 bg-white/5 p-6 text-center backdrop-blur-xl"
+          >
+            <button
+              onClick={onGuest}
+              className="mb-4 rounded-md bg-green-500/20 px-6 py-3 text-green-300 hover:bg-green-500/30"
+            >
+              Try as Guest
+            </button>
+            <p className="text-xs text-white/60">{content.guestNote}</p>
+          </motion.div>
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/src/ui/components/kaizen/FAQ.tsx
+++ b/src/ui/components/kaizen/FAQ.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import Container from './Container';
+
+interface QA {
+  q: string;
+  a: string;
+}
+
+export default function FAQ({ items }: { items: QA[] }) {
+  return (
+    <section id="faq" className="py-24">
+      <Container>
+        <h2 className="mb-8 text-center text-2xl font-semibold">FAQ</h2>
+        <div className="mx-auto max-w-2xl space-y-4">
+          {items.map((qa) => (
+            <details key={qa.q} className="rounded-lg border border-white/10 bg-white/5 p-4 backdrop-blur-xl">
+              <summary className="cursor-pointer font-medium">{qa.q}</summary>
+              <p className="mt-2 text-sm text-white/80">{qa.a}</p>
+            </details>
+          ))}
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/src/ui/components/kaizen/Features.tsx
+++ b/src/ui/components/kaizen/Features.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import Container from './Container';
+
+interface Feature {
+  title: string;
+  text: string;
+}
+
+export default function Features({ features }: { features: Feature[] }) {
+  return (
+    <section id="features" className="py-24">
+      <Container>
+        <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+          {features.map((f, i) => (
+            <motion.div
+              key={f.title}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, delay: i * 0.05, ease: 'easeOut' }}
+              className="rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur-xl"
+            >
+              <svg
+                className="mb-4 h-6 w-6 text-green-400"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <path d="M8 12h8M12 8v8" />
+              </svg>
+              <h3 className="mb-2 font-semibold">{f.title}</h3>
+              <p className="text-sm text-white/80">{f.text}</p>
+            </motion.div>
+          ))}
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/src/ui/components/kaizen/FinalCTA.tsx
+++ b/src/ui/components/kaizen/FinalCTA.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import Container from './Container';
+
+interface FinalContent {
+  primary: string;
+  secondary: string;
+  note: string;
+}
+
+interface Props {
+  content: FinalContent;
+  onPrimary: () => void;
+}
+
+export default function FinalCTA({ content, onPrimary }: Props) {
+  return (
+    <section id="contact" className="py-24">
+      <Container>
+        <div className="text-center">
+          <h2 className="mb-6 text-2xl font-semibold">Ready to learn?</h2>
+          <div className="mb-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <button
+              onClick={onPrimary}
+              className="rounded-xl border border-green-400/50 bg-green-500/20 px-8 py-3 font-medium text-green-300 shadow hover:bg-green-500/30"
+            >
+              {content.primary}
+            </button>
+            <a
+              href="mailto:contact@example.com"
+              className="text-sm text-white/80 hover:text-white"
+            >
+              {content.secondary}
+            </a>
+          </div>
+          <p className="text-xs text-white/60">{content.note}</p>
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/src/ui/components/kaizen/Footer.tsx
+++ b/src/ui/components/kaizen/Footer.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import Container from './Container';
+
+export default function Footer() {
+  return (
+    <footer className="mt-24 border-t border-white/10 py-8 text-sm text-white/60">
+      <Container>
+        <div className="flex flex-col items-center justify-between gap-4 sm:flex-row">
+          <p>© {new Date().getFullYear()} Kaizen Learning</p>
+          <div className="flex gap-4">
+            <a href="#" className="hover:text-white">Privacy</a>
+            <a href="#" className="hover:text-white">Terms</a>
+            <a href="mailto:contact@example.com" className="hover:text-white">
+              Email
+            </a>
+          </div>
+          <div className="flex gap-3">
+            <span aria-label="Twitter" role="img">🐦</span>
+            <span aria-label="LinkedIn" role="img">💼</span>
+          </div>
+        </div>
+      </Container>
+    </footer>
+  );
+}

--- a/src/ui/components/kaizen/Header.tsx
+++ b/src/ui/components/kaizen/Header.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface NavItem {
+  id: string;
+  label: string;
+}
+
+interface HeaderProps {
+  items: NavItem[];
+  onStart: () => void;
+}
+
+export default function Header({ items, onStart }: HeaderProps) {
+  const [active, setActive] = useState(items[0]?.id);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const observers: IntersectionObserver[] = [];
+    items.forEach((item) => {
+      const el = document.getElementById(item.id);
+      if (!el) return;
+      const obs = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) setActive(item.id);
+          });
+        },
+        { threshold: 0.5 }
+      );
+      obs.observe(el);
+      observers.push(obs);
+    });
+    return () => observers.forEach((o) => o.disconnect());
+  }, [items]);
+
+  const handleClick = (id: string) => {
+    document.getElementById(id)?.scrollIntoView({ behavior: 'smooth' });
+    setOpen(false);
+  };
+
+  return (
+    <header className="fixed top-0 z-50 w-full bg-black/40 backdrop-blur-xl">
+      <nav className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
+        <span className="text-lg font-semibold">Kaizen</span>
+        <button
+          className="sm:hidden"
+          onClick={() => setOpen((v) => !v)}
+          aria-label="Toggle menu"
+        >
+          ☰
+        </button>
+        <ul
+          className={`${open ? 'block' : 'hidden'} absolute left-0 top-full w-full bg-black/90 p-4 sm:static sm:flex sm:w-auto sm:space-x-6 sm:bg-transparent sm:p-0`}
+        >
+          {items.map((item) => (
+            <li key={item.id}>
+              <button
+                onClick={() => handleClick(item.id)}
+                className={`text-sm font-medium hover:text-green-400 ${
+                  active === item.id ? 'text-green-400' : 'text-white'
+                }`}
+              >
+                {item.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+        <div className="hidden sm:block">
+          <button
+            onClick={onStart}
+            className="rounded-md bg-green-500/20 px-4 py-2 text-sm text-green-300 shadow hover:bg-green-500/30"
+          >
+            Start
+          </button>
+        </div>
+      </nav>
+    </header>
+  );
+}

--- a/src/ui/components/kaizen/Hero.tsx
+++ b/src/ui/components/kaizen/Hero.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { motion, useScroll, useTransform, useReducedMotion } from 'framer-motion';
+import SideCircuit from './SideCircuit';
+import Container from './Container';
+
+interface HeroProps {
+  content: {
+    title: string;
+    subtitle: string;
+    bullets: string[];
+    primaryCta: string;
+    secondaryCta: string;
+  };
+  onPrimary: () => void;
+  onSecondary: () => void;
+}
+
+export default function Hero({ content, onPrimary, onSecondary }: HeroProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const { scrollYProgress } = useScroll();
+  const leftMove = useTransform(scrollYProgress, [0, 1], ['-5%', '0%']);
+  const rightMove = useTransform(scrollYProgress, [0, 1], ['5%', '0%']);
+
+  return (
+    <section
+      id="intro"
+      className="relative flex min-h-screen items-center justify-center overflow-hidden bg-gradient-to-b from-gray-900 to-black"
+    >
+      <SideCircuit style={{ x: prefersReducedMotion ? 0 : leftMove }} />
+      <SideCircuit mirrored style={{ x: prefersReducedMotion ? 0 : rightMove }} />
+      <Container>
+        <div className="mx-auto max-w-xl text-center">
+          <motion.h1
+            className="mb-6 text-4xl font-bold sm:text-6xl"
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, ease: 'easeOut' }}
+          >
+            {content.title}
+          </motion.h1>
+          <motion.p
+            className="mb-8 text-lg text-white/80 sm:text-2xl"
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.2, duration: 0.6, ease: 'easeOut' }}
+          >
+            {content.subtitle}
+          </motion.p>
+          <ul className="mb-8 space-y-2 text-left text-white/80">
+            {content.bullets.map((b) => (
+              <li key={b} className="flex items-start gap-2">
+                <span className="mt-1 h-2 w-2 rounded-full bg-green-400" />
+                <span>{b}</span>
+              </li>
+            ))}
+          </ul>
+          <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+            <button
+              onClick={onPrimary}
+              className="rounded-xl border border-green-400/50 bg-green-500/20 px-8 py-3 font-medium text-green-300 shadow hover:bg-green-500/30"
+            >
+              {content.primaryCta}
+            </button>
+            <button
+              onClick={onSecondary}
+              className="text-sm text-white/80 hover:text-white"
+            >
+              {content.secondaryCta}
+            </button>
+          </div>
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/src/ui/components/kaizen/HowItWorks.tsx
+++ b/src/ui/components/kaizen/HowItWorks.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import Container from './Container';
+
+interface Step {
+  title: string;
+  text: string;
+}
+
+export default function HowItWorks({ steps }: { steps: Step[] }) {
+  return (
+    <section id="how" className="py-24">
+      <Container>
+        <div className="grid gap-8 md:grid-cols-3">
+          {steps.map((step, i) => (
+            <motion.div
+              key={step.title}
+              initial={{ opacity: 0, y: 20, scale: 0.95 }}
+              whileInView={{ opacity: 1, y: 0, scale: 1 }}
+              transition={{ duration: 0.6, delay: i * 0.1, ease: 'easeOut' }}
+              className="rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur-xl"
+            >
+              <h3 className="mb-2 text-lg font-semibold">{step.title}</h3>
+              <p className="text-sm text-white/80">{step.text}</p>
+            </motion.div>
+          ))}
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/src/ui/components/kaizen/Intro.tsx
+++ b/src/ui/components/kaizen/Intro.tsx
@@ -21,10 +21,10 @@ export default function Intro({ onStart }: IntroProps) {
   const bgY = useTransform(scrollYProgress, [0, 1], ['0%', '20%']);
 
   return (
-    <section
-      className="relative flex min-h-screen items-center justify-center overflow-hidden bg-gradient-to-b from-gray-900 to-black bg-[length:100%_150%] text-white"
-      style={{ backgroundPositionY: bgY }}
-    >
+      <section
+        className="relative flex min-h-screen items-center justify-center overflow-hidden bg-gradient-to-b from-gray-900 to-black bg-[length:100%_150%] text-white"
+        style={{ backgroundPositionY: bgY as unknown as string }}
+      >
       <SideSvg style={{ x: leftX, color, filter: glow }} />
       <SideSvg mirrored style={{ x: rightX, color, filter: glow }} />
       <div className="px-4 text-center">

--- a/src/ui/components/kaizen/Pricing.tsx
+++ b/src/ui/components/kaizen/Pricing.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import Container from './Container';
+
+interface Tier {
+  name: string;
+  priceText: string;
+  features: string[];
+  cta: string;
+}
+
+interface PricingProps {
+  tiers: Tier[];
+  note: string;
+}
+
+export default function Pricing({ tiers, note }: PricingProps) {
+  return (
+    <section id="pricing" className="py-24">
+      <Container>
+        <div className="grid gap-8 md:grid-cols-3">
+          {tiers.map((tier, i) => (
+            <motion.div
+              key={tier.name}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, delay: i * 0.1, ease: 'easeOut' }}
+              className="flex flex-col rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur-xl"
+            >
+              <h3 className="mb-2 text-xl font-semibold">{tier.name}</h3>
+              <p className="mb-4 text-white/70">{tier.priceText}</p>
+              <ul className="mb-6 flex-1 space-y-2 text-sm">
+                {tier.features.map((f) => (
+                  <li key={f} className="flex items-center gap-2">
+                    <span className="h-2 w-2 rounded-full bg-green-400" />
+                    <span>{f}</span>
+                  </li>
+                ))}
+              </ul>
+              <button
+                onClick={() => console.log(tier.cta)}
+                className="rounded-md bg-green-500/20 px-4 py-2 text-sm text-green-300 hover:bg-green-500/30"
+              >
+                {tier.cta}
+              </button>
+            </motion.div>
+          ))}
+        </div>
+        <p className="mt-6 text-center text-xs text-white/60">{note}</p>
+      </Container>
+    </section>
+  );
+}

--- a/src/ui/components/kaizen/Roadmap.tsx
+++ b/src/ui/components/kaizen/Roadmap.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import Container from './Container';
+
+interface Item {
+  title: string;
+  eta: string;
+  text: string;
+}
+
+export default function Roadmap({ items }: { items: Item[] }) {
+  return (
+    <section id="roadmap" className="py-24">
+      <Container>
+        <h2 className="mb-8 text-center text-2xl font-semibold">Roadmap</h2>
+        <ul className="mx-auto max-w-2xl border-l border-white/20 pl-6">
+          {items.map((item) => (
+            <li key={item.title} className="relative mb-8 last:mb-0">
+              <span className="absolute -left-3 top-1 h-2 w-2 rounded-full bg-green-400" />
+              <div className="mb-1 font-semibold">
+                {item.title}{' '}
+                <span className="text-sm font-normal text-white/60">{item.eta}</span>
+              </div>
+              <p className="text-sm text-white/80">{item.text}</p>
+            </li>
+          ))}
+        </ul>
+      </Container>
+    </section>
+  );
+}

--- a/src/ui/components/kaizen/SecurityPrivacy.tsx
+++ b/src/ui/components/kaizen/SecurityPrivacy.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Container from './Container';
+import { motion } from 'framer-motion';
+
+interface MiniFaq {
+  q: string;
+  a: string;
+}
+
+interface SecurityProps {
+  content: { bullets: string[]; miniFaq: MiniFaq[] };
+}
+
+export default function SecurityPrivacy({ content }: SecurityProps) {
+  return (
+    <section id="security" className="py-24">
+      <Container>
+        <h2 className="mb-8 text-2xl font-semibold">Security & Privacy</h2>
+        <ul className="mb-8 space-y-3">
+          {content.bullets.map((b) => (
+            <motion.li
+              key={b}
+              initial={{ opacity: 0, x: -10 }}
+              whileInView={{ opacity: 1, x: 0 }}
+              transition={{ duration: 0.4, ease: 'easeOut' }}
+              className="flex items-start gap-2"
+            >
+              <span className="mt-1 h-2 w-2 flex-none rounded-full bg-green-400" />
+              <span>{b}</span>
+            </motion.li>
+          ))}
+        </ul>
+        <div className="space-y-4">
+          {content.miniFaq.map((f) => (
+            <details key={f.q} className="rounded-lg border border-white/10 bg-white/5 p-4 backdrop-blur-xl">
+              <summary className="cursor-pointer font-medium">{f.q}</summary>
+              <p className="mt-2 text-sm text-white/80">{f.a}</p>
+            </details>
+          ))}
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/src/ui/components/kaizen/SideCircuit.tsx
+++ b/src/ui/components/kaizen/SideCircuit.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { motion, MotionProps } from 'framer-motion';
+
+interface SideCircuitProps extends MotionProps {
+  mirrored?: boolean;
+}
+
+export default function SideCircuit({ mirrored, ...props }: SideCircuitProps) {
+  return (
+    <motion.svg
+      aria-hidden
+      viewBox="0 0 100 400"
+      className={`pointer-events-none absolute top-0 h-full w-20 opacity-50 ${
+        mirrored ? 'right-0 rotate-180' : 'left-0'
+      }`}
+      {...props}
+    >
+      <defs>
+        <linearGradient id="circuit" x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0%" stopColor="currentColor" stopOpacity="0" />
+          <stop offset="50%" stopColor="currentColor" stopOpacity="0.4" />
+          <stop offset="100%" stopColor="currentColor" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <path
+        d="M50 0 v100 q0 10 -10 10 h-20 q-10 0 -10 10 v40 q0 10 10 10 h20 q10 0 10 10 v210"
+        stroke="url(#circuit)"
+        strokeWidth="2"
+        fill="none"
+      />
+    </motion.svg>
+  );
+}

--- a/src/ui/components/kaizen/Testimonials.tsx
+++ b/src/ui/components/kaizen/Testimonials.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import Container from './Container';
+
+interface Testimonial {
+  quote: string;
+  name: string;
+  role: string;
+}
+
+export default function Testimonials({ items }: { items: Testimonial[] }) {
+  return (
+    <section id="testimonials" className="py-24">
+      <Container>
+        <h2 className="mb-8 text-center text-2xl font-semibold">Testimonials</h2>
+        <div className="grid gap-8 md:grid-cols-3">
+          {items.map((t, i) => (
+            <motion.blockquote
+              key={t.quote}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, delay: i * 0.1, ease: 'easeOut' }}
+              className="rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur-xl"
+            >
+              <p className="mb-4 text-sm text-white/80">“{t.quote}”</p>
+              <footer className="text-xs text-white/60">
+                {t.name}, {t.role}
+              </footer>
+            </motion.blockquote>
+          ))}
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,7 @@ module.exports = {
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/ui/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   darkMode: false,
   theme: {


### PR DESCRIPTION
## Summary
- render full Kaizen landing page in introduction route

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a83a4e4690832e879aa0dce54ff73c