### PR TITLE
Adjust Kaizen intro page for light theme

### DIFF
--- a/src/app/kaizen/introduction/page.tsx
+++ b/src/app/kaizen/introduction/page.tsx
@@ -34,9 +34,9 @@ export default function KaizenIntroductionPage() {
   ];
 
   return (
-    <div className="font-sans text-white">
+    <div className="font-sans overflow-x-hidden text-black">
       <Header items={navItems} onStart={() => setModalOpen(true)} />
-      <main className="pt-16">
+      <main>
         <Hero
           content={defaultContent.hero}
           onPrimary={() => setModalOpen(true)}

--- a/src/ui/components/kaizen/Benefits.tsx
+++ b/src/ui/components/kaizen/Benefits.tsx
@@ -19,7 +19,7 @@ export default function Benefits({ content }: BenefitsProps) {
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, ease: 'easeOut' }}
-            className="text-white/80"
+            className="text-black/80"
           >
             {content.paragraph}
           </motion.p>

--- a/src/ui/components/kaizen/Demo.tsx
+++ b/src/ui/components/kaizen/Demo.tsx
@@ -20,13 +20,13 @@ export default function Demo({ content, onGuest }: DemoProps) {
     <section id="demo" className="py-24">
       <Container>
         <h2 className="mb-8 text-center text-2xl font-semibold">{content.title}</h2>
-        <p className="mb-8 text-center text-white/70">{content.subtitle}</p>
+        <p className="mb-8 text-center text-black/70">{content.subtitle}</p>
         <div className="grid gap-8 md:grid-cols-2">
           <motion.pre
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, ease: 'easeOut' }}
-            className="overflow-auto rounded-2xl border border-white/10 bg-white/5 p-4 text-sm backdrop-blur-xl"
+            className="overflow-auto rounded-2xl border border-black/10 bg-black/5 p-4 text-sm backdrop-blur-xl"
           >
             <code>{content.leftMockJson}</code>
           </motion.pre>
@@ -34,7 +34,7 @@ export default function Demo({ content, onGuest }: DemoProps) {
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, delay: 0.1, ease: 'easeOut' }}
-            className="flex flex-col items-center justify-center rounded-2xl border border-white/10 bg-white/5 p-6 text-center backdrop-blur-xl"
+            className="flex flex-col items-center justify-center rounded-2xl border border-black/10 bg-black/5 p-6 text-center backdrop-blur-xl"
           >
             <button
               onClick={onGuest}
@@ -42,7 +42,7 @@ export default function Demo({ content, onGuest }: DemoProps) {
             >
               Try as Guest
             </button>
-            <p className="text-xs text-white/60">{content.guestNote}</p>
+            <p className="text-xs text-black/60">{content.guestNote}</p>
           </motion.div>
         </div>
       </Container>

--- a/src/ui/components/kaizen/FAQ.tsx
+++ b/src/ui/components/kaizen/FAQ.tsx
@@ -14,9 +14,9 @@ export default function FAQ({ items }: { items: QA[] }) {
         <h2 className="mb-8 text-center text-2xl font-semibold">FAQ</h2>
         <div className="mx-auto max-w-2xl space-y-4">
           {items.map((qa) => (
-            <details key={qa.q} className="rounded-lg border border-white/10 bg-white/5 p-4 backdrop-blur-xl">
+            <details key={qa.q} className="rounded-lg border border-black/10 bg-black/5 p-4 backdrop-blur-xl">
               <summary className="cursor-pointer font-medium">{qa.q}</summary>
-              <p className="mt-2 text-sm text-white/80">{qa.a}</p>
+              <p className="mt-2 text-sm text-black/80">{qa.a}</p>
             </details>
           ))}
         </div>

--- a/src/ui/components/kaizen/Features.tsx
+++ b/src/ui/components/kaizen/Features.tsx
@@ -19,7 +19,7 @@ export default function Features({ features }: { features: Feature[] }) {
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6, delay: i * 0.05, ease: 'easeOut' }}
-              className="rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur-xl"
+              className="rounded-2xl border border-black/10 bg-black/5 p-6 backdrop-blur-xl"
             >
               <svg
                 className="mb-4 h-6 w-6 text-green-400"
@@ -32,7 +32,7 @@ export default function Features({ features }: { features: Feature[] }) {
                 <path d="M8 12h8M12 8v8" />
               </svg>
               <h3 className="mb-2 font-semibold">{f.title}</h3>
-              <p className="text-sm text-white/80">{f.text}</p>
+              <p className="text-sm text-black/80">{f.text}</p>
             </motion.div>
           ))}
         </div>

--- a/src/ui/components/kaizen/FinalCTA.tsx
+++ b/src/ui/components/kaizen/FinalCTA.tsx
@@ -28,12 +28,12 @@ export default function FinalCTA({ content, onPrimary }: Props) {
             </button>
             <a
               href="mailto:contact@example.com"
-              className="text-sm text-white/80 hover:text-white"
+              className="text-sm text-black/80 hover:text-black"
             >
               {content.secondary}
             </a>
           </div>
-          <p className="text-xs text-white/60">{content.note}</p>
+          <p className="text-xs text-black/60">{content.note}</p>
         </div>
       </Container>
     </section>

--- a/src/ui/components/kaizen/Footer.tsx
+++ b/src/ui/components/kaizen/Footer.tsx
@@ -4,14 +4,14 @@ import Container from './Container';
 
 export default function Footer() {
   return (
-    <footer className="mt-24 border-t border-white/10 py-8 text-sm text-white/60">
+    <footer className="mt-24 border-t border-black/10 py-8 text-sm text-black/60">
       <Container>
         <div className="flex flex-col items-center justify-between gap-4 sm:flex-row">
           <p>© {new Date().getFullYear()} Kaizen Learning</p>
           <div className="flex gap-4">
-            <a href="#" className="hover:text-white">Privacy</a>
-            <a href="#" className="hover:text-white">Terms</a>
-            <a href="mailto:contact@example.com" className="hover:text-white">
+            <a href="#" className="hover:text-black">Privacy</a>
+            <a href="#" className="hover:text-black">Terms</a>
+            <a href="mailto:contact@example.com" className="hover:text-black">
               Email
             </a>
           </div>

--- a/src/ui/components/kaizen/Header.tsx
+++ b/src/ui/components/kaizen/Header.tsx
@@ -41,9 +41,9 @@ export default function Header({ items, onStart }: HeaderProps) {
   };
 
   return (
-    <header className="fixed top-0 z-50 w-full bg-black/40 backdrop-blur-xl">
+    <header className="fixed top-0 z-50 w-full bg-white backdrop-blur-xl">
       <nav className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
-        <span className="text-lg font-semibold">Kaizen</span>
+        <span className="text-lg font-semibold text-black">Kaizen</span>
         <button
           className="sm:hidden"
           onClick={() => setOpen((v) => !v)}
@@ -52,14 +52,14 @@ export default function Header({ items, onStart }: HeaderProps) {
           ☰
         </button>
         <ul
-          className={`${open ? 'block' : 'hidden'} absolute left-0 top-full w-full bg-black/90 p-4 sm:static sm:flex sm:w-auto sm:space-x-6 sm:bg-transparent sm:p-0`}
+          className={`${open ? 'block' : 'hidden'} absolute left-0 top-full w-full bg-white p-4 sm:static sm:flex sm:w-auto sm:space-x-6 sm:bg-transparent sm:p-0`}
         >
           {items.map((item) => (
             <li key={item.id}>
               <button
                 onClick={() => handleClick(item.id)}
                 className={`text-sm font-medium hover:text-green-400 ${
-                  active === item.id ? 'text-green-400' : 'text-white'
+                  active === item.id ? 'text-green-400' : 'text-black'
                 }`}
               >
                 {item.label}

--- a/src/ui/components/kaizen/HowItWorks.tsx
+++ b/src/ui/components/kaizen/HowItWorks.tsx
@@ -19,10 +19,10 @@ export default function HowItWorks({ steps }: { steps: Step[] }) {
               initial={{ opacity: 0, y: 20, scale: 0.95 }}
               whileInView={{ opacity: 1, y: 0, scale: 1 }}
               transition={{ duration: 0.6, delay: i * 0.1, ease: 'easeOut' }}
-              className="rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur-xl"
+              className="rounded-2xl border border-black/10 bg-black/5 p-6 backdrop-blur-xl"
             >
-              <h3 className="mb-2 text-lg font-semibold">{step.title}</h3>
-              <p className="text-sm text-white/80">{step.text}</p>
+              <h3 className="mb-2 text-lg font-semibold text-black">{step.title}</h3>
+              <p className="text-sm text-black/80">{step.text}</p>
             </motion.div>
           ))}
         </div>

--- a/src/ui/components/kaizen/Pricing.tsx
+++ b/src/ui/components/kaizen/Pricing.tsx
@@ -26,10 +26,10 @@ export default function Pricing({ tiers, note }: PricingProps) {
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6, delay: i * 0.1, ease: 'easeOut' }}
-              className="flex flex-col rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur-xl"
+              className="flex flex-col rounded-2xl border border-black/10 bg-black/5 p-6 backdrop-blur-xl"
             >
               <h3 className="mb-2 text-xl font-semibold">{tier.name}</h3>
-              <p className="mb-4 text-white/70">{tier.priceText}</p>
+              <p className="mb-4 text-black/70">{tier.priceText}</p>
               <ul className="mb-6 flex-1 space-y-2 text-sm">
                 {tier.features.map((f) => (
                   <li key={f} className="flex items-center gap-2">
@@ -47,7 +47,7 @@ export default function Pricing({ tiers, note }: PricingProps) {
             </motion.div>
           ))}
         </div>
-        <p className="mt-6 text-center text-xs text-white/60">{note}</p>
+        <p className="mt-6 text-center text-xs text-black/60">{note}</p>
       </Container>
     </section>
   );

--- a/src/ui/components/kaizen/Roadmap.tsx
+++ b/src/ui/components/kaizen/Roadmap.tsx
@@ -13,15 +13,15 @@ export default function Roadmap({ items }: { items: Item[] }) {
     <section id="roadmap" className="py-24">
       <Container>
         <h2 className="mb-8 text-center text-2xl font-semibold">Roadmap</h2>
-        <ul className="mx-auto max-w-2xl border-l border-white/20 pl-6">
+        <ul className="mx-auto max-w-2xl border-l border-black/20 pl-6">
           {items.map((item) => (
             <li key={item.title} className="relative mb-8 last:mb-0">
               <span className="absolute -left-3 top-1 h-2 w-2 rounded-full bg-green-400" />
               <div className="mb-1 font-semibold">
                 {item.title}{' '}
-                <span className="text-sm font-normal text-white/60">{item.eta}</span>
+                <span className="text-sm font-normal text-black/60">{item.eta}</span>
               </div>
-              <p className="text-sm text-white/80">{item.text}</p>
+              <p className="text-sm text-black/80">{item.text}</p>
             </li>
           ))}
         </ul>

--- a/src/ui/components/kaizen/SecurityPrivacy.tsx
+++ b/src/ui/components/kaizen/SecurityPrivacy.tsx
@@ -33,9 +33,9 @@ export default function SecurityPrivacy({ content }: SecurityProps) {
         </ul>
         <div className="space-y-4">
           {content.miniFaq.map((f) => (
-            <details key={f.q} className="rounded-lg border border-white/10 bg-white/5 p-4 backdrop-blur-xl">
+            <details key={f.q} className="rounded-lg border border-black/10 bg-black/5 p-4 backdrop-blur-xl">
               <summary className="cursor-pointer font-medium">{f.q}</summary>
-              <p className="mt-2 text-sm text-white/80">{f.a}</p>
+              <p className="mt-2 text-sm text-black/80">{f.a}</p>
             </details>
           ))}
         </div>

--- a/src/ui/components/kaizen/Testimonials.tsx
+++ b/src/ui/components/kaizen/Testimonials.tsx
@@ -21,10 +21,10 @@ export default function Testimonials({ items }: { items: Testimonial[] }) {
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6, delay: i * 0.1, ease: 'easeOut' }}
-              className="rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur-xl"
+              className="rounded-2xl border border-black/10 bg-black/5 p-6 backdrop-blur-xl"
             >
-              <p className="mb-4 text-sm text-white/80">“{t.quote}”</p>
-              <footer className="text-xs text-white/60">
+              <p className="mb-4 text-sm text-black/80">“{t.quote}”</p>
+              <footer className="text-xs text-black/60">
                 {t.name}, {t.role}
               </footer>
             </motion.blockquote>


### PR DESCRIPTION
## Summary
- Remove extra scroll space and hide horizontal overflow on Kaizen intro page
- Realign header with white background and black navigation text
- Convert feature sections to black text with light borders for readability

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a848795658832ea7c7004fb9e2309c