### PR TITLE
feat: improve green button visibility

### DIFF
--- a/src/ui/components/kaizen/AuthModal.tsx
+++ b/src/ui/components/kaizen/AuthModal.tsx
@@ -55,7 +55,7 @@ export default function AuthModal({ open, onClose, initialTab = 'login' }: AuthM
                 />
                 <button
                   onClick={() => console.log('login')}
-                  className="w-full rounded-md bg-green-500/20 py-2 text-green-300 hover:bg-green-500/30"
+                  className="w-full rounded-md bg-green-500/20 py-2 text-black text-center hover:bg-green-500/30"
                 >
                   Continue
                 </button>
@@ -68,7 +68,7 @@ export default function AuthModal({ open, onClose, initialTab = 'login' }: AuthM
                 <p>Continue as guest with limited quota.</p>
                 <button
                   onClick={() => console.log('startGuestTrial')}
-                  className="w-full rounded-md bg-green-500/20 py-2 text-green-300 hover:bg-green-500/30"
+                  className="w-full rounded-md bg-green-500/20 py-2 text-black text-center hover:bg-green-500/30"
                 >
                   Continue as Guest
                 </button>

--- a/src/ui/components/kaizen/Demo.tsx
+++ b/src/ui/components/kaizen/Demo.tsx
@@ -38,7 +38,7 @@ export default function Demo({ content, onGuest }: DemoProps) {
           >
             <button
               onClick={onGuest}
-              className="mb-4 rounded-md bg-green-500/20 px-6 py-3 text-green-300 hover:bg-green-500/30"
+              className="mb-4 rounded-md bg-green-500/20 px-6 py-3 text-black text-center hover:bg-green-500/30"
             >
               Try as Guest
             </button>

--- a/src/ui/components/kaizen/FinalCTA.tsx
+++ b/src/ui/components/kaizen/FinalCTA.tsx
@@ -22,7 +22,7 @@ export default function FinalCTA({ content, onPrimary }: Props) {
           <div className="mb-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
             <button
               onClick={onPrimary}
-              className="rounded-xl border border-green-400/50 bg-green-500/20 px-8 py-3 font-medium text-green-300 shadow hover:bg-green-500/30"
+              className="rounded-xl border border-green-400/50 bg-green-500/20 px-8 py-3 font-medium text-black text-center shadow hover:bg-green-500/30"
             >
               {content.primary}
             </button>

--- a/src/ui/components/kaizen/Header.tsx
+++ b/src/ui/components/kaizen/Header.tsx
@@ -70,7 +70,7 @@ export default function Header({ items, onStart }: HeaderProps) {
         <div className="hidden sm:block">
           <button
             onClick={onStart}
-            className="rounded-md bg-green-500/20 px-4 py-2 text-sm text-green-300 shadow hover:bg-green-500/30"
+            className="rounded-md bg-green-500/20 px-4 py-2 text-sm text-black text-center shadow hover:bg-green-500/30"
           >
             Start
           </button>

--- a/src/ui/components/kaizen/Hero.tsx
+++ b/src/ui/components/kaizen/Hero.tsx
@@ -58,7 +58,7 @@ export default function Hero({ content, onPrimary, onSecondary }: HeroProps) {
           <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
             <button
               onClick={onPrimary}
-              className="rounded-xl border border-green-400/50 bg-green-500/20 px-8 py-3 font-medium text-green-300 shadow hover:bg-green-500/30"
+              className="rounded-xl border border-green-400/50 bg-green-500/20 px-8 py-3 font-medium text-black text-center shadow hover:bg-green-500/30"
             >
               {content.primaryCta}
             </button>

--- a/src/ui/components/kaizen/KaizenModal.tsx
+++ b/src/ui/components/kaizen/KaizenModal.tsx
@@ -42,7 +42,7 @@ export default function KaizenModal({ open, onClose }: KaizenModalProps) {
               />
               <button
                 type="submit"
-                className="w-full rounded bg-green-500/20 py-2 text-green-300 transition hover:bg-green-500/30"
+                className="w-full rounded bg-green-500/20 py-2 text-black text-center transition hover:bg-green-500/30"
               >
                 Login
               </button>

--- a/src/ui/components/kaizen/Pricing.tsx
+++ b/src/ui/components/kaizen/Pricing.tsx
@@ -40,7 +40,7 @@ export default function Pricing({ tiers, note }: PricingProps) {
               </ul>
               <button
                 onClick={() => console.log(tier.cta)}
-                className="rounded-md bg-green-500/20 px-4 py-2 text-sm text-green-300 hover:bg-green-500/30"
+                className="rounded-md bg-green-500/20 px-4 py-2 text-sm text-black text-center hover:bg-green-500/30"
               >
                 {tier.cta}
               </button>


### PR DESCRIPTION
## Summary
- use centered black text on green call-to-action buttons for better visibility

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8578556f8832eb296efcf8d883c50