### PR TITLE
feat: add Kaizen home shell with profile context

### DIFF
--- a/src/app/kaizen/home/page.tsx
+++ b/src/app/kaizen/home/page.tsx
@@ -1,0 +1,10 @@
+import ChatHomeShell from '../../../components/kaizen/ChatHomeShell';
+import { KaizenProvider } from '../../../components/kaizen/KaizenContext';
+
+export default function KaizenHomePage() {
+  return (
+    <KaizenProvider>
+      <ChatHomeShell />
+    </KaizenProvider>
+  );
+}

--- a/src/components/kaizen/ChatHomeShell.tsx
+++ b/src/components/kaizen/ChatHomeShell.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import ChatPane from './ChatPane';
+import ProfilePanel from './ProfilePanel';
+
+export default function ChatHomeShell() {
+  return (
+    <div className="min-h-screen flex flex-col bg-neutral-900 text-white font-sans">
+      <header className="sticky top-0 z-10 bg-white/10 backdrop-blur border-b border-white/20">
+        <nav className="mx-auto flex max-w-7xl items-center justify-between p-4 text-sm">
+          <a href="/kaizen/home" className="font-bold text-green-400">
+            Kaizen
+          </a>
+          <div className="space-x-4">
+            <a href="/kaizen/home" className="hover:underline">
+              Home
+            </a>
+            <a href="/kaizen/introduction" className="hover:underline">
+              Intro
+            </a>
+          </div>
+        </nav>
+      </header>
+      <main className="flex flex-1 flex-col md:flex-row">
+        <section className="flex-1 border-b md:border-b-0 md:border-r border-white/10">
+          <ChatPane />
+        </section>
+        <aside className="w-full md:w-80 lg:w-96">
+          <ProfilePanel />
+        </aside>
+      </main>
+      <footer className="border-t border-white/10 bg-white/5 backdrop-blur p-4 text-center text-xs">
+        <a href="#" className="mx-2 underline hover:no-underline">
+          Privacy
+        </a>
+        <a href="#" className="mx-2 underline hover:no-underline">
+          Terms
+        </a>
+      </footer>
+    </div>
+  );
+}

--- a/src/components/kaizen/ChatPane.tsx
+++ b/src/components/kaizen/ChatPane.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useState } from 'react';
+import { motion } from 'framer-motion';
+import { useKaizen } from './KaizenContext';
+
+export default function ChatPane() {
+  const {
+    threads,
+    createThread,
+    deleteThread,
+    messagesByThread,
+    appendMessage,
+  } = useKaizen();
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [input, setInput] = useState('');
+
+  const handleSend = () => {
+    if (!activeId || !input.trim()) return;
+    appendMessage(activeId, {
+      id: crypto.randomUUID(),
+      role: 'user',
+      content: input.trim(),
+      createdAt: new Date().toISOString(),
+    });
+    // TODO: handle assistant reply via API
+    setInput('');
+  };
+
+  const msgs = activeId ? messagesByThread[activeId] || [] : [];
+
+  return (
+    <div className="h-full flex">
+      <aside className="w-48 shrink-0 border-r border-white/10 p-2 space-y-2 bg-white/5 backdrop-blur">
+        <button
+          onClick={() => {
+            const id = createThread('New Thread');
+            setActiveId(id);
+          }}
+          className="w-full rounded bg-white/10 px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-green-400"
+        >
+          + New
+        </button>
+        <ul className="space-y-1 overflow-y-auto" aria-label="Conversation list">
+          {threads.map(t => (
+            <li key={t.id} className="flex items-center gap-1">
+              <button
+                onClick={() => setActiveId(t.id)}
+                className={`flex-1 text-left px-2 py-1 rounded hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-green-400 ${
+                  activeId === t.id ? 'bg-white/10' : ''
+                }`}
+              >
+                <span className="block truncate text-sm">{t.title}</span>
+              </button>
+              <button
+                onClick={() => deleteThread(t.id)}
+                aria-label="Delete thread"
+                className="text-xs text-red-400 hover:text-red-600 focus:outline-none focus:ring-2 focus:ring-green-400"
+              >
+                ×
+              </button>
+            </li>
+          ))}
+        </ul>
+      </aside>
+      <section className="flex-1 flex flex-col">
+        <div className="flex-1 overflow-y-auto p-4 space-y-4">
+          {msgs.map(m => (
+            <motion.p
+              key={m.id}
+              initial={{ opacity: 0, y: 4 }}
+              animate={{ opacity: 1, y: 0 }}
+              className={`max-w-prose rounded bg-white/5 p-2 text-sm ${
+                m.role === 'user' ? 'self-end bg-green-500/20' : ''
+              }`}
+            >
+              {m.content}
+            </motion.p>
+          ))}
+        </div>
+        <div className="border-t border-white/10 p-2">
+          <label htmlFor="chat-input" className="sr-only">
+            Message
+          </label>
+          <input
+            id="chat-input"
+            value={input}
+            onChange={e => setInput(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                handleSend();
+              }
+            }}
+            placeholder="Type a message..."
+            className="w-full rounded bg-white/10 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-400"
+          />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/components/kaizen/KaizenContext.tsx
+++ b/src/components/kaizen/KaizenContext.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { createContext, useContext, useState, useEffect } from 'react';
+import { LearnerProfile, ChatMessage } from './types';
+
+type ThreadMeta = { id: string; title: string; createdAt: string };
+
+type KaizenContextType = {
+  profile: LearnerProfile;
+  setProfile: (partial: Partial<LearnerProfile>) => void;
+  threads: ThreadMeta[];
+  createThread: (title: string) => string;
+  deleteThread: (id: string) => void;
+  messagesByThread: Record<string, ChatMessage[]>;
+  appendMessage: (threadId: string, msg: ChatMessage) => void;
+};
+
+const defaultProfile: LearnerProfile = {
+  language: 'en',
+  topic: '',
+  targetProficiency: 3,
+  weeklyHours: 5,
+  sessionLengthMin: 45,
+  priorKnowledge: [],
+  strategies: {
+    spacedRepetition: true,
+    retrievalPractice: true,
+    interleaving: true,
+    workedExamples: true,
+    reflectionPrompts: true,
+  },
+  explanationPracticeRatio: 0.5,
+  difficultyPreference: 'balanced',
+  assessmentPrefs: {
+    format: ['mcq'],
+    microQuizEveryMin: 8,
+  },
+};
+
+const KaizenContext = createContext<KaizenContextType | undefined>(undefined);
+
+export function KaizenProvider({ children }: { children: React.ReactNode }) {
+  const [profile, setProfileState] = useState<LearnerProfile>(defaultProfile);
+  const [threads, setThreads] = useState<ThreadMeta[]>([]);
+  const [messagesByThread, setMessagesByThread] = useState<Record<string, ChatMessage[]>>({});
+
+  useEffect(() => {
+    try {
+      const p = localStorage.getItem('kaizen_profile_v1');
+      const t = localStorage.getItem('kaizen_threads_v1');
+      const m = localStorage.getItem('kaizen_msgs_v1');
+      if (p) setProfileState(JSON.parse(p));
+      if (t) setThreads(JSON.parse(t));
+      if (m) setMessagesByThread(JSON.parse(m));
+    } catch {
+      // ignore malformed JSON
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('kaizen_profile_v1', JSON.stringify(profile));
+  }, [profile]);
+
+  useEffect(() => {
+    localStorage.setItem('kaizen_threads_v1', JSON.stringify(threads));
+  }, [threads]);
+
+  useEffect(() => {
+    localStorage.setItem('kaizen_msgs_v1', JSON.stringify(messagesByThread));
+  }, [messagesByThread]);
+
+  const setProfile = (partial: Partial<LearnerProfile>) =>
+    setProfileState(prev => ({ ...prev, ...partial }));
+
+  const createThread = (title: string) => {
+    const id = crypto.randomUUID();
+    const createdAt = new Date().toISOString();
+    const thread = { id, title, createdAt };
+    setThreads(prev => [...prev, thread]);
+    return id;
+  };
+
+  const deleteThread = (id: string) => {
+    setThreads(prev => prev.filter(t => t.id !== id));
+    setMessagesByThread(prev => {
+      const updated = { ...prev };
+      delete updated[id];
+      return updated;
+    });
+  };
+
+  const appendMessage = (threadId: string, msg: ChatMessage) => {
+    setMessagesByThread(prev => ({
+      ...prev,
+      [threadId]: [...(prev[threadId] || []), msg],
+    }));
+  };
+
+  return (
+    <KaizenContext.Provider
+      value={{
+        profile,
+        setProfile,
+        threads,
+        createThread,
+        deleteThread,
+        messagesByThread,
+        appendMessage,
+      }}
+    >
+      {children}
+    </KaizenContext.Provider>
+  );
+}
+
+export function useKaizen() {
+  const ctx = useContext(KaizenContext);
+  if (!ctx) throw new Error('useKaizen must be used within KaizenProvider');
+  return ctx;
+}

--- a/src/components/kaizen/ProfilePanel.tsx
+++ b/src/components/kaizen/ProfilePanel.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useKaizen } from './KaizenContext';
+import type { ProficiencyScale } from './types';
+
+export default function ProfilePanel() {
+  const { profile, setProfile } = useKaizen();
+  return (
+    <form className="h-full overflow-y-auto space-y-4 bg-white/5 backdrop-blur p-4 text-sm">
+      <div>
+        <label htmlFor="language" className="block mb-1">
+          Language
+        </label>
+        <select
+          id="language"
+          value={profile.language}
+          onChange={e => setProfile({ language: e.target.value as 'en' | 'fr' })}
+          className="w-full rounded bg-white/10 p-2 focus:outline-none focus:ring-2 focus:ring-green-400"
+        >
+          <option value="en">English</option>
+          <option value="fr">Français</option>
+        </select>
+      </div>
+      <div>
+        <label htmlFor="topic" className="block mb-1">
+          Topic
+        </label>
+        <input
+          id="topic"
+          value={profile.topic}
+          onChange={e => setProfile({ topic: e.target.value })}
+          className="w-full rounded bg-white/10 p-2 focus:outline-none focus:ring-2 focus:ring-green-400"
+        />
+      </div>
+      <div>
+        <label htmlFor="preciseSubject" className="block mb-1">
+          Precise subject
+        </label>
+        <input
+          id="preciseSubject"
+          value={profile.preciseSubject || ''}
+          onChange={e => setProfile({ preciseSubject: e.target.value })}
+          className="w-full rounded bg-white/10 p-2 focus:outline-none focus:ring-2 focus:ring-green-400"
+        />
+      </div>
+      <div>
+        <label htmlFor="target" className="block mb-1">
+          Target proficiency
+        </label>
+        <select
+          id="target"
+          value={profile.targetProficiency}
+          onChange={e =>
+            setProfile({
+              targetProficiency: Number(e.target.value) as ProficiencyScale,
+            })
+          }
+          className="w-full rounded bg-white/10 p-2 focus:outline-none focus:ring-2 focus:ring-green-400"
+        >
+          {[0,1,2,3,4,5].map(n => (
+            <option key={n} value={n}>{n}</option>
+          ))}
+        </select>
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <label htmlFor="weekly" className="block mb-1">
+            Weekly hours
+          </label>
+          <input
+            id="weekly"
+            type="number"
+            min={0}
+            value={profile.weeklyHours}
+            onChange={e => setProfile({ weeklyHours: Number(e.target.value) })}
+            className="w-full rounded bg-white/10 p-2 focus:outline-none focus:ring-2 focus:ring-green-400"
+          />
+        </div>
+        <div>
+          <label htmlFor="session" className="block mb-1">
+            Session length (min)
+          </label>
+          <input
+            id="session"
+            type="number"
+            min={15}
+            max={120}
+            value={profile.sessionLengthMin}
+            onChange={e => setProfile({ sessionLengthMin: Number(e.target.value) })}
+            className="w-full rounded bg-white/10 p-2 focus:outline-none focus:ring-2 focus:ring-green-400"
+          />
+        </div>
+      </div>
+      <fieldset className="space-y-2">
+        <legend className="font-medium">Strategies</legend>
+        {(
+          [
+            ['spacedRepetition', 'Spaced repetition'],
+            ['retrievalPractice', 'Retrieval practice'],
+            ['interleaving', 'Interleaving'],
+            ['workedExamples', 'Worked examples'],
+            ['reflectionPrompts', 'Reflection prompts'],
+          ] as const
+        ).map(([key, label]) => (
+          <label key={key} className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={profile.strategies[key]}
+              onChange={e =>
+                setProfile({
+                  strategies: { ...profile.strategies, [key]: e.target.checked },
+                })
+              }
+              className="h-4 w-4 rounded focus:ring-2 focus:ring-green-400"
+            />
+            <span>{label}</span>
+          </label>
+        ))}
+      </fieldset>
+    </form>
+  );
+}

--- a/src/components/kaizen/types.ts
+++ b/src/components/kaizen/types.ts
@@ -1,0 +1,76 @@
+export type ProficiencyScale = 0|1|2|3|4|5; // 0=none, 5=expert
+
+export type PrereqConcept = {
+  name: string;
+  selfRatedMastery: ProficiencyScale; // user-estimated
+  notes?: string;
+};
+
+export type LearnerProfile = {
+  language: 'en'|'fr';
+  topic: string;                 // e.g., "Linear Algebra"
+  preciseSubject?: string;       // e.g., "Eigenvalues and eigenvectors"
+  targetProficiency: ProficiencyScale;
+  deadlineISO?: string;          // e.g., "2025-10-01"
+  weeklyHours: number;           // commitment signal
+  sessionLengthMin: number;      // 15–120
+  priorKnowledge: PrereqConcept[];
+  knownMisconceptions?: string[]; // short labels
+  constraints?: string[];         // e.g., "mobile-only", "no video"
+  examplesDomain?: 'math'|'cs'|'science'|'business'|'everyday';
+  explanationPracticeRatio: number; // 0..1 (0=all practice, 1=all explanation)
+  difficultyPreference: 'gentle'|'balanced'|'challenging'; // desirable difficulty target
+  strategies: {
+    spacedRepetition: boolean;
+    retrievalPractice: boolean;
+    interleaving: boolean;
+    workedExamples: boolean;
+    reflectionPrompts: boolean; // metacognitive checks
+  };
+  assessmentPrefs: {
+    format: ('mcq'|'short-answer'|'coding'|'proof')[];
+    microQuizEveryMin: number; // e.g., 6–10
+  };
+  accessibility?: {
+    dyslexiaFriendly?: boolean;
+    highContrast?: boolean;
+    captions?: boolean;
+  };
+};
+
+export type ChatMessage = {
+  id: string;
+  role: 'user'|'assistant'|'system';
+  content: string;
+  createdAt: string;
+};
+
+export type LessonRequest = {
+  topic: string;
+  preciseSubject?: string;
+  learnerProfile: LearnerProfile;
+  chatHistory: ChatMessage[];
+  requestMeta: {
+    sessionId: string;
+    locale: 'en'|'fr';
+    maxTokens: number;
+  };
+};
+
+export type LessonResponse = {
+  overview: string;
+  prerequisites: { name: string; brief: string }[];
+  lessonPlan: Array<{
+    step: number;
+    title: string;
+    explain: string;
+    example?: string;
+    check?: string; // quick self-check question
+    practice?: string[]; // exercises/prompts
+    estMinutes: number;
+  }>;
+  spacedSchedule?: Array<{ dayOffset: number; activity: string }>;
+  microQuizzes?: Array<{ question: string; answers: string[]; correctIndex: number; explanation: string }>;
+  references?: string[]; // urls or titles (to be filtered server-side)
+  safetyNotes?: string[]; // domain-specific cautions
+};


### PR DESCRIPTION
## Summary
- add Kaizen home page wrapping ChatHomeShell in context provider
- implement type-safe learner profile and lesson schemas
- create context store syncing profile, threads and messages to localStorage
- build responsive chat and profile panels with glassmorphism header/footer

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a862164684832eac49e5d79e81a7af