### PR TITLE
feat: add Kaizen chat interface

### DIFF
--- a/src/app/kaizen/chat/[id]/page.tsx
+++ b/src/app/kaizen/chat/[id]/page.tsx
@@ -1,8 +1,8 @@
-import ChatHomeShell from '../../../components/kaizen/ChatHomeShell';
-import { KaizenProvider } from '../../../components/kaizen/KaizenContext';
+import ChatHomeShell from '../../../../components/kaizen/ChatHomeShell';
+import { KaizenProvider } from '../../../../components/kaizen/KaizenContext';
 import Link from 'next/link';
 
-export default function KaizenHomePage() {
+export default function ChatThreadPage({ params }: { params: { id: string } }) {
   return (
     <div className="min-h-screen flex flex-col bg-gradient-to-br from-gray-900 to-black text-white font-sans">
       <header className="border-b border-white/10 bg-white/5 backdrop-blur">
@@ -15,7 +15,7 @@ export default function KaizenHomePage() {
         </nav>
       </header>
       <KaizenProvider>
-        <main className="flex-1"><ChatHomeShell /></main>
+        <main className="flex-1"><ChatHomeShell initialThreadId={params.id} /></main>
       </KaizenProvider>
       <footer className="border-t border-white/10 bg-white/5 backdrop-blur p-4 text-center text-xs">© Kaizen</footer>
     </div>

--- a/src/components/kaizen/ChatHomeShell.tsx
+++ b/src/components/kaizen/ChatHomeShell.tsx
@@ -1,42 +1,58 @@
 'use client';
-
+import { useEffect, useState } from 'react';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import Sidebar from './Sidebar';
 import ChatPane from './ChatPane';
-import MyDataPanel from './MyDataPanel';
+import { useKaizen } from './KaizenContext';
+import { buildLessonRequest } from './request';
+import { Button } from './ui';
+import Link from 'next/link';
+import { routes } from './routes';
 
-export default function ChatHomeShell() {
+type Props = { initialThreadId?: string };
+
+export default function ChatHomeShell({ initialThreadId }: Props) {
+  const { profile, messagesByThread, activeThreadId, setActiveThreadId, threads } = useKaizen();
+  const [drawer, setDrawer] = useState(false);
+  const prefersReduced = useReducedMotion();
+
+  useEffect(() => { if (initialThreadId) setActiveThreadId(initialThreadId); }, [initialThreadId, setActiveThreadId]);
+
+  const handleGenerate = () => {
+    const req = buildLessonRequest({
+      profile,
+      chatHistory: activeThreadId ? messagesByThread[activeThreadId] || [] : [],
+      sessionId: activeThreadId || crypto.randomUUID(),
+    });
+    console.log('LessonRequest', req);
+    // TODO: fetch('/api/lessons/generate', { method: 'POST', body: JSON.stringify(req) })
+  };
+
+  const threadExists = activeThreadId ? threads.some(t => t.id === activeThreadId) : true;
+  if (initialThreadId && !threadExists)
+    return (
+      <div className="p-8 text-center">
+        <p className="mb-4">Thread not found — create a new chat</p>
+        <Link href={routes.home} className="underline text-green-400">Go home</Link>
+      </div>
+    );
+
   return (
-    <div className="min-h-screen flex flex-col bg-neutral-900 text-white font-sans">
-      <header className="sticky top-0 z-10 bg-white/10 backdrop-blur border-b border-white/20">
-        <nav className="mx-auto flex max-w-7xl items-center justify-between p-4 text-sm">
-          <a href="/kaizen/home" className="font-bold text-green-400">
-            Kaizen
-          </a>
-          <div className="space-x-4">
-            <a href="/kaizen/home" className="hover:underline">
-              Home
-            </a>
-            <a href="/kaizen/introduction" className="hover:underline">
-              Intro
-            </a>
-          </div>
-        </nav>
-      </header>
-      <main className="flex flex-1 flex-col md:flex-row">
-        <section className="flex-1 border-b md:border-b-0 md:border-r border-white/10">
-          <ChatPane />
-        </section>
-        <aside className="w-full md:w-80 lg:w-96">
-          <MyDataPanel />
-        </aside>
-      </main>
-      <footer className="border-t border-white/10 bg-white/5 backdrop-blur p-4 text-center text-xs">
-        <a href="#" className="mx-2 underline hover:no-underline">
-          Privacy
-        </a>
-        <a href="#" className="mx-2 underline hover:no-underline">
-          Terms
-        </a>
-      </footer>
+    <div className="flex h-full">
+      <aside className="hidden md:block w-72 shrink-0 border-r border-white/10"><Sidebar /></aside>
+      <AnimatePresence>
+        {drawer && (
+          <motion.aside initial={{ x: -300 }} animate={{ x: 0 }} exit={{ x: -300 }} transition={{ duration: prefersReduced ? 0 : 0.2 }} className="fixed inset-y-0 left-0 z-20 w-72 bg-black/80 backdrop-blur-md border-r border-white/10 md:hidden">
+            <Sidebar onNavigate={() => setDrawer(false)} />
+          </motion.aside>
+        )}
+      </AnimatePresence>
+      <div className="flex-1 flex flex-col">
+        <div className="flex justify-end p-2 border-b border-white/10">
+          <Button onClick={handleGenerate} className="text-xs px-2 py-1">Generate Lesson (Preview)</Button>
+        </div>
+        <ChatPane onOpenSidebar={() => setDrawer(true)} />
+      </div>
     </div>
   );
 }

--- a/src/components/kaizen/MyDataPanel.tsx
+++ b/src/components/kaizen/MyDataPanel.tsx
@@ -1,374 +1,40 @@
 'use client';
-
+import { useMemo } from 'react';
 import { useKaizen } from './KaizenContext';
-import type { ProficiencyScale, PrereqConcept, LessonRequest, LearnerProfile } from './types';
-
-function buildLessonRequest(
-  profile: LearnerProfile,
-  chatHistory: LessonRequest['chatHistory'],
-  sessionId: string
-): LessonRequest {
-  return {
-    topic: profile.topic,
-    preciseSubject: profile.preciseSubject,
-    learnerProfile: profile,
-    chatHistory,
-    requestMeta: {
-      sessionId,
-      locale: profile.language,
-      maxTokens: 2000,
-    },
-  };
-}
+import { PrereqConcept, ProficiencyScale } from './types';
+import { buildLessonRequest } from './request';
+import { Button } from './ui';
 
 export default function MyDataPanel() {
   const { profile, setProfile, messagesByThread, activeThreadId } = useKaizen();
-
-  const updatePrereq = (index: number, partial: Partial<PrereqConcept>) => {
-    const next = [...profile.priorKnowledge];
-    next[index] = { ...next[index], ...partial };
-    setProfile({ priorKnowledge: next });
-  };
-
-  const addPrereq = () =>
-    setProfile({
-      priorKnowledge: [
-        ...profile.priorKnowledge,
-        { name: '', selfRatedMastery: 0, notes: '' },
-      ],
-    });
-
-  const removePrereq = (index: number) => {
-    const next = profile.priorKnowledge.filter((_, i) => i !== index);
-    setProfile({ priorKnowledge: next });
-  };
-
-  const lessonReq = buildLessonRequest(
-    profile,
-    activeThreadId ? messagesByThread[activeThreadId] || [] : [],
-    activeThreadId || crypto.randomUUID()
-  );
-  const preview = JSON.stringify(lessonReq, null, 2);
-
-  const formats = ['mcq', 'short-answer', 'coding', 'proof'] as const;
-
+  const updatePrereq = (i:number,p:Partial<PrereqConcept>)=>{const list=[...profile.priorKnowledge];list[i]={...list[i],...p};setProfile({priorKnowledge:list});};
+  const addPrereq=()=>setProfile({priorKnowledge:[...profile.priorKnowledge,{name:'',selfRatedMastery:0}]});
+  const removePrereq=(i:number)=>setProfile({priorKnowledge:profile.priorKnowledge.filter((_,j)=>j!==i)});
+  const lessonReq=useMemo(()=>buildLessonRequest({profile,chatHistory:activeThreadId?messagesByThread[activeThreadId]||[]:[],sessionId:activeThreadId||crypto.randomUUID()}),[profile,messagesByThread,activeThreadId]);
+  const preview=useMemo(()=>JSON.stringify(lessonReq,null,2),[lessonReq]);
+  const strategies=[['spacedRepetition','Spaced repetition','Review near the forgetting curve.'],['retrievalPractice','Retrieval practice','Answer from memory first.'],['interleaving','Interleaving','Mix related topics for transfer.'],['workedExamples','Worked examples','Study step-by-step solutions.'],['reflectionPrompts','Reflection prompts','Brief self-explanations.']] as const;
+  const formats=['mcq','short-answer','coding','proof'] as const;
+  const accessibility=[['dyslexiaFriendly','Dyslexia-friendly'],['highContrast','High contrast'],['captions','Captions']] as const;
   return (
-    <div className="h-full overflow-y-auto bg-white/5 backdrop-blur p-4 space-y-4 text-sm">
-      <form className="space-y-4">
-        <div>
-          <label htmlFor="language" className="block mb-1">
-            Language
-          </label>
-          <select
-            id="language"
-            value={profile.language}
-            onChange={e => setProfile({ language: e.target.value as 'en' | 'fr' })}
-            className="w-full rounded bg-white/10 p-2 focus:outline-none focus:ring-2 focus:ring-green-400"
-          >
-            <option value="en">English</option>
-            <option value="fr">Français</option>
-          </select>
-        </div>
-        <div>
-          <label htmlFor="topic" className="block mb-1">
-            Topic
-          </label>
-          <input
-            id="topic"
-            value={profile.topic}
-            onChange={e => setProfile({ topic: e.target.value })}
-            className="w-full rounded bg-white/10 p-2 focus:outline-none focus:ring-2 focus:ring-green-400"
-          />
-        </div>
-        <div>
-          <label htmlFor="preciseSubject" className="block mb-1">
-            Precise subject
-          </label>
-          <input
-            id="preciseSubject"
-            value={profile.preciseSubject || ''}
-            onChange={e => setProfile({ preciseSubject: e.target.value })}
-            className="w-full rounded bg-white/10 p-2 focus:outline-none focus:ring-2 focus:ring-green-400"
-          />
-        </div>
-        <div>
-          <label htmlFor="target" className="block mb-1">
-            Target proficiency: {profile.targetProficiency}
-          </label>
-          <input
-            type="range"
-            id="target"
-            min={0}
-            max={5}
-            step={1}
-            value={profile.targetProficiency}
-            onChange={e =>
-              setProfile({
-                targetProficiency: Number(e.target.value) as ProficiencyScale,
-              })
-            }
-            className="w-full"
-          />
-        </div>
-        <div>
-          <label htmlFor="deadline" className="block mb-1">
-            Deadline
-          </label>
-          <input
-            type="date"
-            id="deadline"
-            value={profile.deadlineISO || ''}
-            onChange={e => setProfile({ deadlineISO: e.target.value })}
-            className="w-full rounded bg-white/10 p-2 focus:outline-none focus:ring-2 focus:ring-green-400"
-          />
-        </div>
-        <div className="grid grid-cols-2 gap-2">
-          <div>
-            <label htmlFor="weekly" className="block mb-1">
-              Weekly hours
-            </label>
-            <input
-              type="number"
-              id="weekly"
-              min={0}
-              value={profile.weeklyHours}
-              onChange={e => setProfile({ weeklyHours: Number(e.target.value) })}
-              className="w-full rounded bg-white/10 p-2 focus:outline-none focus:ring-2 focus:ring-green-400"
-            />
-          </div>
-          <div>
-            <label htmlFor="sessionLen" className="block mb-1">
-              Session length (min)
-            </label>
-            <input
-              type="number"
-              id="sessionLen"
-              min={15}
-              max={120}
-              step={5}
-              value={profile.sessionLengthMin}
-              onChange={e =>
-                setProfile({ sessionLengthMin: Number(e.target.value) })
-              }
-              className="w-full rounded bg-white/10 p-2 focus:outline-none focus:ring-2 focus:ring-green-400"
-            />
-          </div>
-        </div>
-        <div>
-          <div className="flex items-center justify-between mb-1">
-            <span className="font-medium">Prerequisites</span>
-            <button
-              type="button"
-              onClick={addPrereq}
-              className="rounded bg-white/10 px-2 py-1 text-xs"
-            >
-              + Add
-            </button>
-          </div>
-          {profile.priorKnowledge.map((p, i) => (
-            <div key={i} className="mb-2 space-y-1 rounded bg-white/5 p-2">
-              <div className="flex gap-2">
-                <input
-                  value={p.name}
-                  onChange={e => updatePrereq(i, { name: e.target.value })}
-                  placeholder="Concept"
-                  className="flex-1 rounded bg-white/10 p-1"
-                />
-                <input
-                  type="number"
-                  min={0}
-                  max={5}
-                  value={p.selfRatedMastery}
-                  onChange={e =>
-                    updatePrereq(i, {
-                      selfRatedMastery: Number(e.target.value) as ProficiencyScale,
-                    })
-                  }
-                  className="w-16 rounded bg-white/10 p-1"
-                />
-              </div>
-              <div className="flex gap-2">
-                <input
-                  value={p.notes || ''}
-                  onChange={e => updatePrereq(i, { notes: e.target.value })}
-                  placeholder="Notes"
-                  className="flex-1 rounded bg-white/10 p-1"
-                />
-                <button
-                  type="button"
-                  onClick={() => removePrereq(i)}
-                  className="rounded bg-red-500/30 px-2 py-1 text-xs"
-                >
-                  Remove
-                </button>
-              </div>
-            </div>
-          ))}
-        </div>
-        <fieldset className="space-y-2">
-          <legend className="font-medium">Strategies</legend>
-          {(
-            [
-              ['spacedRepetition', 'Spaced repetition'],
-              ['retrievalPractice', 'Retrieval practice'],
-              ['interleaving', 'Interleaving'],
-              ['workedExamples', 'Worked examples'],
-              ['reflectionPrompts', 'Reflection'],
-            ] as const
-          ).map(([key, label]) => (
-            <label key={key} className="flex items-center gap-2">
-              <input
-                type="checkbox"
-                checked={profile.strategies[key]}
-                onChange={e =>
-                  setProfile({
-                    strategies: {
-                      ...profile.strategies,
-                      [key]: e.target.checked,
-                    },
-                  })
-                }
-                className="h-4 w-4 rounded focus:ring-2 focus:ring-green-400"
-              />
-              <span>{label}</span>
-            </label>
-          ))}
-        </fieldset>
-        <div>
-          <label htmlFor="ratio" className="block mb-1">
-            Explanation vs practice ratio: {profile.explanationPracticeRatio.toFixed(2)}
-          </label>
-          <input
-            type="range"
-            id="ratio"
-            min={0}
-            max={1}
-            step={0.01}
-            value={profile.explanationPracticeRatio}
-            onChange={e =>
-              setProfile({
-                explanationPracticeRatio: Number(e.target.value),
-              })
-            }
-            className="w-full"
-          />
-        </div>
-        <fieldset>
-          <legend className="font-medium mb-1">Difficulty</legend>
-          {(
-            [
-              ['gentle', 'Gentle'],
-              ['balanced', 'Balanced'],
-              ['challenging', 'Challenging'],
-            ] as const
-          ).map(([val, label]) => (
-            <label key={val} className="mr-4">
-              <input
-                type="radio"
-                name="difficulty"
-                value={val}
-                checked={profile.difficultyPreference === val}
-                onChange={e =>
-                  setProfile({
-                    difficultyPreference: e.target.value as typeof val,
-                  })
-                }
-                className="mr-1"
-              />
-              {label}
-            </label>
-          ))}
-        </fieldset>
-        <fieldset className="space-y-2">
-          <legend className="font-medium">Assessment</legend>
-          <div className="flex flex-wrap gap-2">
-            {formats.map(f => (
-              <label key={f} className="flex items-center gap-1">
-                <input
-                  type="checkbox"
-                  checked={profile.assessmentPrefs.format.includes(f)}
-                  onChange={e => {
-                    const list = profile.assessmentPrefs.format;
-                    const next = e.target.checked
-                      ? [...list, f]
-                      : list.filter(x => x !== f);
-                    setProfile({
-                      assessmentPrefs: {
-                        ...profile.assessmentPrefs,
-                        format: next,
-                      },
-                    });
-                  }}
-                />
-                <span>{f}</span>
-              </label>
-            ))}
-          </div>
-          <div>
-            <label htmlFor="micro" className="block mb-1">
-              Micro-quiz every (min)
-            </label>
-            <input
-              type="number"
-              id="micro"
-              min={1}
-              value={profile.assessmentPrefs.microQuizEveryMin}
-              onChange={e =>
-                setProfile({
-                  assessmentPrefs: {
-                    ...profile.assessmentPrefs,
-                    microQuizEveryMin: Number(e.target.value),
-                  },
-                })
-              }
-              className="w-full rounded bg-white/10 p-2 focus:outline-none focus:ring-2 focus:ring-green-400"
-            />
-          </div>
-        </fieldset>
-        <fieldset className="space-y-2">
-          <legend className="font-medium">Accessibility</legend>
-          {(
-            [
-              ['dyslexiaFriendly', 'Dyslexia-friendly'],
-              ['highContrast', 'High contrast'],
-              ['captions', 'Captions'],
-            ] as const
-          ).map(([key, label]) => (
-            <label key={key} className="flex items-center gap-2">
-              <input
-                type="checkbox"
-                checked={profile.accessibility?.[key] || false}
-                onChange={e =>
-                  setProfile({
-                    accessibility: {
-                      ...profile.accessibility,
-                      [key]: e.target.checked,
-                    },
-                  })
-                }
-                className="h-4 w-4 rounded focus:ring-2 focus:ring-green-400"
-              />
-              <span>{label}</span>
-            </label>
-          ))}
-        </fieldset>
-      </form>
-      <div>
-        <label className="block mb-1">LessonRequest Preview</label>
-        <textarea
-          readOnly
-          value={preview}
-          className="w-full h-48 rounded bg-black/50 p-2 font-mono text-xs"
-        />
-        <button
-          type="button"
-          onClick={() => navigator.clipboard.writeText(preview)}
-          className="mt-2 rounded bg-white/10 px-2 py-1 text-xs"
-        >
-          Copy request JSON
-        </button>
+    <div className="space-y-4 text-sm">
+      <div className="grid grid-cols-2 gap-2">
+        <label><span className="block mb-1">Language</span><select value={profile.language} onChange={e=>setProfile({language:e.target.value as 'en'|'fr'})} className="w-full rounded bg-white/10 p-1"><option value="en">English</option><option value="fr">Français</option></select></label>
+        <label><span className="block mb-1">Topic</span><input value={profile.topic} onChange={e=>setProfile({topic:e.target.value})} className="w-full rounded bg-white/10 p-1"/></label>
+        <label className="col-span-2"><span className="block mb-1">Precise subject</span><input value={profile.preciseSubject||''} onChange={e=>setProfile({preciseSubject:e.target.value})} className="w-full rounded bg-white/10 p-1"/></label>
+        <label className="col-span-2"><span className="block mb-1">Target proficiency: {profile.targetProficiency}</span><input type="range" min={0} max={5} value={profile.targetProficiency} onChange={e=>setProfile({targetProficiency:Number(e.target.value) as ProficiencyScale})} className="w-full"/></label>
+        <label><span className="block mb-1">Deadline</span><input type="date" value={profile.deadlineISO||''} onChange={e=>setProfile({deadlineISO:e.target.value})} className="w-full rounded bg-white/10 p-1"/></label>
+        <label><span className="block mb-1">Weekly hours</span><input type="number" min={1} max={30} value={profile.weeklyHours} onChange={e=>setProfile({weeklyHours:Number(e.target.value)})} className="w-full rounded bg-white/10 p-1"/></label>
+        <label><span className="block mb-1">Session length (min)</span><input type="number" min={15} max={120} step={5} value={profile.sessionLengthMin} onChange={e=>setProfile({sessionLengthMin:Number(e.target.value)})} className="w-full rounded bg-white/10 p-1"/></label>
       </div>
+      <div>
+        <div className="flex items-center justify-between mb-1"><span>Prerequisites</span><Button type="button" onClick={addPrereq} className="px-2 py-0 text-xs">+ Add</Button></div>
+        {profile.priorKnowledge.map((p,i)=>(<div key={i} className="mb-2 flex gap-2 text-xs"><input value={p.name} onChange={e=>updatePrereq(i,{name:e.target.value})} placeholder="Name" className="flex-1 rounded bg-white/10 p-1"/><input type="number" min={0} max={5} value={p.selfRatedMastery} onChange={e=>updatePrereq(i,{selfRatedMastery:Number(e.target.value) as ProficiencyScale})} className="w-14 rounded bg-white/10 p-1"/><input value={p.notes||''} onChange={e=>updatePrereq(i,{notes:e.target.value})} placeholder="Notes" className="flex-1 rounded bg-white/10 p-1"/><Button type="button" onClick={()=>removePrereq(i)} className="px-2 py-0 text-xs bg-red-500/30">×</Button></div>))}
+      </div>
+      <fieldset className="space-y-1"><legend className="font-medium">Strategies</legend>{strategies.map(([k,l,t])=>(<label key={k} className="flex items-center gap-2" title={t}><input type="checkbox" checked={profile.strategies[k]} onChange={e=>setProfile({strategies:{...profile.strategies,[k]:e.target.checked}})} className="h-4 w-4 rounded"/><span>{l}</span></label>))}</fieldset>
+      <fieldset className="space-x-4"><legend className="font-medium mb-1">Difficulty</legend>{(['gentle','balanced','challenging'] as const).map(d=>(<label key={d} className="text-sm"><input type="radio" name="difficulty" value={d} checked={profile.difficultyPreference===d} onChange={e=>setProfile({difficultyPreference:e.target.value as typeof d})} className="mr-1"/>{d}</label>))}</fieldset>
+      <fieldset className="space-y-1"><legend className="font-medium">Assessment</legend><div className="flex flex-wrap gap-2">{formats.map(f=>(<label key={f} className="flex items-center gap-1"><input type="checkbox" checked={profile.assessmentPrefs.format.includes(f)} onChange={e=>{const list=profile.assessmentPrefs.format;const next=e.target.checked?[...list,f]:list.filter(x=>x!==f);setProfile({assessmentPrefs:{...profile.assessmentPrefs,format:next}});}}/><span>{f}</span></label>))}</div><label className="block"><span className="mr-2">Micro-quiz every (min)</span><input type="number" min={4} max={15} value={profile.assessmentPrefs.microQuizEveryMin} onChange={e=>setProfile({assessmentPrefs:{...profile.assessmentPrefs,microQuizEveryMin:Number(e.target.value)}})} className="w-20 rounded bg-white/10 p-1"/></label></fieldset>
+      <fieldset className="space-y-1"><legend className="font-medium">Accessibility</legend>{accessibility.map(([k,l])=>(<label key={k} className="flex items-center gap-2"><input type="checkbox" checked={profile.accessibility?.[k as keyof typeof profile.accessibility]||false} onChange={e=>setProfile({accessibility:{...profile.accessibility,[k]:e.target.checked}})} className="h-4 w-4 rounded"/><span>{l}</span></label>))}</fieldset>
+      <div><label className="block mb-1">Preview JSON</label><textarea readOnly value={preview} className="w-full h-40 rounded bg-black/50 p-2 font-mono text-xs"/><Button type="button" onClick={()=>navigator.clipboard.writeText(preview)} className="mt-1 px-2 py-1 text-xs">Copy JSON</Button></div>
     </div>
   );
 }
-

--- a/src/components/kaizen/Sidebar.tsx
+++ b/src/components/kaizen/Sidebar.tsx
@@ -1,0 +1,119 @@
+'use client';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
+import { useKaizen } from './KaizenContext';
+import MyDataPanel from './MyDataPanel';
+import { routes } from './routes';
+import { Button, GlassCard, Icon } from './ui';
+
+type Props = { onNavigate?: () => void };
+
+export default function Sidebar({ onNavigate }: Props) {
+  const {
+    profile,
+    threads,
+    createThread,
+    activeThreadId,
+    setActiveThreadId,
+    sidebarOpen,
+    setSidebarOpen,
+  } = useKaizen();
+  const router = useRouter();
+  const prefersReduced = useReducedMotion();
+
+  const relative = (iso: string) => {
+    const diff = Date.now() - new Date(iso).getTime();
+    const mins = Math.floor(diff / 60000);
+    if (mins < 60) return `${mins}m ago`;
+    const hrs = Math.floor(mins / 60);
+    if (hrs < 24) return `${hrs}h ago`;
+    return `${Math.floor(hrs / 24)}d ago`;
+  };
+
+  const newChat = () => {
+    const title =
+      profile.preciseSubject ||
+      (profile.topic ? `Start the topic: ${profile.topic}` : 'Untitled chat');
+    const id = createThread(title);
+    setActiveThreadId(id);
+    router.push(routes.chat(id));
+    onNavigate?.();
+  };
+
+  const openThread = (id: string) => {
+    setActiveThreadId(id);
+    router.push(routes.chat(id));
+    onNavigate?.();
+  };
+
+  useEffect(() => {}, [sidebarOpen]); // trigger re-render on mount for persisted state
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between p-2">
+        <Button className="flex-1" onClick={newChat}>
+          New Chat
+        </Button>
+        <button
+          aria-label="Settings"
+          className="ml-2 text-white/60 hover:text-white"
+        >
+          <Icon>⚙️</Icon>
+        </button>
+      </div>
+      <ul className="flex-1 overflow-y-auto px-2">
+        {threads.map(t => (
+          <li key={t.id} className="my-1">
+            <button
+              onClick={() => openThread(t.id)}
+              className={`w-full rounded px-2 py-1 text-left text-sm ${
+                activeThreadId === t.id ? 'bg-white/10 text-green-400' : 'hover:bg-white/5'
+              }`}
+            >
+              <div className="truncate">{t.title || 'Untitled'}</div>
+              <div className="text-xs text-white/50">{relative(t.createdAt)}</div>
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div className="p-2">
+        <GlassCard className="p-2">
+          <button
+            onClick={() => setSidebarOpen(!sidebarOpen)}
+            className="w-full text-left text-sm font-medium"
+          >
+            My Data
+          </button>
+          <AnimatePresence initial={false}>
+            {sidebarOpen ? (
+              <motion.div
+                key="open"
+                initial={{ height: 0, opacity: 0 }}
+                animate={{ height: 'auto', opacity: 1 }}
+                exit={{ height: 0, opacity: 0 }}
+                transition={{ duration: prefersReduced ? 0 : 0.2 }}
+                className="mt-2"
+              >
+                <MyDataPanel />
+              </motion.div>
+            ) : (
+              <motion.div
+                key="closed"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: prefersReduced ? 0 : 0.2 }}
+                className="mt-2 text-xs text-white/70 space-y-1"
+              >
+                <div>{profile.topic || 'No topic'}</div>
+                <div>Level {profile.targetProficiency}</div>
+                <div>{profile.weeklyHours}h/week</div>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </GlassCard>
+      </div>
+    </div>
+  );
+}

--- a/src/components/kaizen/request.ts
+++ b/src/components/kaizen/request.ts
@@ -1,0 +1,24 @@
+import { LearnerProfile, ChatMessage } from './types';
+
+export type LessonRequest = {
+  topic: string;
+  preciseSubject?: string;
+  learnerProfile: LearnerProfile;
+  chatHistory: ChatMessage[];
+  requestMeta: { sessionId: string; locale: 'en'|'fr'; maxTokens: number };
+};
+
+export function buildLessonRequest(args: {
+  profile: LearnerProfile;
+  chatHistory: ChatMessage[];
+  sessionId: string;
+}): LessonRequest {
+  const { profile, chatHistory, sessionId } = args;
+  return {
+    topic: profile.topic,
+    preciseSubject: profile.preciseSubject,
+    learnerProfile: profile,
+    chatHistory,
+    requestMeta: { sessionId, locale: profile.language, maxTokens: 2000 }
+  };
+}

--- a/src/components/kaizen/routes.ts
+++ b/src/components/kaizen/routes.ts
@@ -1,0 +1,4 @@
+export const routes = {
+  home: '/kaizen/home',
+  chat: (id: string) => `/kaizen/chat/${id}`
+};

--- a/src/components/kaizen/types.ts
+++ b/src/components/kaizen/types.ts
@@ -1,35 +1,35 @@
-export type ProficiencyScale = 0|1|2|3|4|5; // 0=none, 5=expert
+export type ProficiencyScale = 0|1|2|3|4|5;
 
 export type PrereqConcept = {
   name: string;
-  selfRatedMastery: ProficiencyScale; // user-estimated
+  selfRatedMastery: ProficiencyScale;
   notes?: string;
 };
 
 export type LearnerProfile = {
   language: 'en'|'fr';
-  topic: string;                 // e.g., "Linear Algebra"
-  preciseSubject?: string;       // e.g., "Eigenvalues and eigenvectors"
+  topic: string;
+  preciseSubject?: string;
   targetProficiency: ProficiencyScale;
-  deadlineISO?: string;          // e.g., "2025-10-01"
-  weeklyHours: number;           // commitment signal
-  sessionLengthMin: number;      // 15–120
+  deadlineISO?: string;
+  weeklyHours: number;
+  sessionLengthMin: number;
   priorKnowledge: PrereqConcept[];
-  knownMisconceptions?: string[]; // short labels
-  constraints?: string[];         // e.g., "mobile-only", "no video"
+  knownMisconceptions?: string[];
+  constraints?: string[];
   examplesDomain?: 'math'|'cs'|'science'|'business'|'everyday';
-  explanationPracticeRatio: number; // 0..1 (0=all practice, 1=all explanation)
-  difficultyPreference: 'gentle'|'balanced'|'challenging'; // desirable difficulty target
+  explanationPracticeRatio: number;
+  difficultyPreference: 'gentle'|'balanced'|'challenging';
   strategies: {
     spacedRepetition: boolean;
     retrievalPractice: boolean;
     interleaving: boolean;
     workedExamples: boolean;
-    reflectionPrompts: boolean; // metacognitive checks
+    reflectionPrompts: boolean;
   };
   assessmentPrefs: {
     format: ('mcq'|'short-answer'|'coding'|'proof')[];
-    microQuizEveryMin: number; // e.g., 6–10
+    microQuizEveryMin: number;
   };
   accessibility?: {
     dyslexiaFriendly?: boolean;
@@ -43,34 +43,4 @@ export type ChatMessage = {
   role: 'user'|'assistant'|'system';
   content: string;
   createdAt: string;
-};
-
-export type LessonRequest = {
-  topic: string;
-  preciseSubject?: string;
-  learnerProfile: LearnerProfile;
-  chatHistory: ChatMessage[];
-  requestMeta: {
-    sessionId: string;
-    locale: 'en'|'fr';
-    maxTokens: number;
-  };
-};
-
-export type LessonResponse = {
-  overview: string;
-  prerequisites: { name: string; brief: string }[];
-  lessonPlan: Array<{
-    step: number;
-    title: string;
-    explain: string;
-    example?: string;
-    check?: string; // quick self-check question
-    practice?: string[]; // exercises/prompts
-    estMinutes: number;
-  }>;
-  spacedSchedule?: Array<{ dayOffset: number; activity: string }>;
-  microQuizzes?: Array<{ question: string; answers: string[]; correctIndex: number; explanation: string }>;
-  references?: string[]; // urls or titles (to be filtered server-side)
-  safetyNotes?: string[]; // domain-specific cautions
 };

--- a/src/components/kaizen/ui.tsx
+++ b/src/components/kaizen/ui.tsx
@@ -1,0 +1,26 @@
+'use client';
+import React from 'react';
+
+const neon = 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-400/70';
+
+export function GlassCard({ className = '', ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={`bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl shadow-lg ${className}`}
+      {...props}
+    />
+  );
+}
+
+export function Button({ className = '', ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      className={`px-3 py-1 rounded-md bg-green-500/20 hover:bg-green-500/30 text-sm ${neon} ${className}`}
+      {...props}
+    />
+  );
+}
+
+export function Icon({ className = '', children }: { className?: string; children: React.ReactNode }) {
+  return <span aria-hidden className={`inline-flex items-center ${className}`}>{children}</span>;
+}


### PR DESCRIPTION
## Summary
- implement responsive chat home shell with sidebar and lesson request preview
- add learner profile editor, chat pane, and context with localStorage persistence
- introduce routing helpers and minimal UI components for Kaizen

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a86cc28258832e86a71a85db76cd6f