### PR TITLE
feat: unify kaizen header and add streaked lessons

### DIFF
--- a/src/app/kaizen/chat/[id]/page.tsx
+++ b/src/app/kaizen/chat/[id]/page.tsx
@@ -1,23 +1,24 @@
 import ChatHomeShell from '../../../../components/kaizen/ChatHomeShell';
 import { KaizenProvider } from '../../../../components/kaizen/KaizenContext';
-import Link from 'next/link';
+import { KAIZEN_PAGE_CLASS } from '../../../../components/kaizen/constants';
+import Header from '@/ui/components/kaizen/Header';
 
 export default function ChatThreadPage({ params }: { params: { id: string } }) {
   return (
-    <div className="min-h-screen flex flex-col bg-gradient-to-br from-gray-900 to-black text-white font-sans">
-      <header className="border-b border-white/10 bg-white/5 backdrop-blur">
-        <nav className="mx-auto max-w-7xl flex justify-between p-4 text-sm">
-          <Link href="/kaizen/home" className="font-bold text-green-400">Kaizen</Link>
-          <div className="space-x-4">
-            <Link href="/kaizen/introduction" className="hover:underline">Intro</Link>
-            <Link href="/kaizen/home" className="hover:underline">Home</Link>
-          </div>
-        </nav>
-      </header>
+    <div className={KAIZEN_PAGE_CLASS}>
+      <Header
+        items={[]}
+        links={[
+          { href: '/kaizen/introduction', label: 'Intro' },
+          { href: '/kaizen/home', label: 'Home' },
+        ]}
+        showStart={false}
+        homeHref="/kaizen/home"
+      />
       <KaizenProvider>
-        <main className="flex flex-1 min-h-0"><ChatHomeShell initialThreadId={params.id} /></main>
+        <main className="flex flex-1 min-h-0 pt-16"><ChatHomeShell initialThreadId={params.id} /></main>
       </KaizenProvider>
-      <footer className="border-t border-white/10 bg-white/5 backdrop-blur p-4 text-center text-xs">© Kaizen</footer>
+      <footer className="border-t border-black/10 bg-white p-4 text-center text-xs">© Kaizen</footer>
     </div>
   );
 }

--- a/src/app/kaizen/home/page.tsx
+++ b/src/app/kaizen/home/page.tsx
@@ -1,21 +1,22 @@
 import ChatHomeShell from '../../../components/kaizen/ChatHomeShell';
 import { KaizenProvider } from '../../../components/kaizen/KaizenContext';
-import Link from 'next/link';
+import { KAIZEN_PAGE_CLASS } from '../../../components/kaizen/constants';
+import Header from '@/ui/components/kaizen/Header';
 
 export default function KaizenHomePage() {
   return (
-    <div className="h-screen flex flex-col bg-white text-black font-sans">
-      <header className="border-b border-black/10 bg-white">
-        <nav className="mx-auto max-w-7xl flex justify-between p-4 text-sm">
-          <Link href="/kaizen/home" className="font-bold text-green-400">Kaizen</Link>
-          <div className="space-x-4">
-            <Link href="/kaizen/introduction" className="hover:underline">Intro</Link>
-            <Link href="/kaizen/home" className="hover:underline">Home</Link>
-          </div>
-        </nav>
-      </header>
+    <div className={KAIZEN_PAGE_CLASS}>
+      <Header
+        items={[]}
+        links={[
+          { href: '/kaizen/introduction', label: 'Intro' },
+          { href: '/kaizen/home', label: 'Home' },
+        ]}
+        showStart={false}
+        homeHref="/kaizen/home"
+      />
       <KaizenProvider>
-        <main className="flex flex-1 min-h-0"><ChatHomeShell /></main>
+        <main className="flex flex-1 min-h-0 pt-16"><ChatHomeShell /></main>
       </KaizenProvider>
       <footer className="border-t border-black/10 bg-white p-4 text-center text-xs">© Kaizen</footer>
     </div>

--- a/src/components/kaizen/ChatHomeShell.tsx
+++ b/src/components/kaizen/ChatHomeShell.tsx
@@ -14,9 +14,14 @@ type Props = { initialThreadId?: string };
 export default function ChatHomeShell({ initialThreadId }: Props) {
   const { profile, messagesByThread, activeThreadId, setActiveThreadId, threads } = useKaizen();
   const [drawer, setDrawer] = useState(false);
+  const [streak, setStreak] = useState(0);
   const prefersReduced = useReducedMotion();
 
   useEffect(() => { if (initialThreadId) setActiveThreadId(initialThreadId); }, [initialThreadId, setActiveThreadId]);
+  useEffect(() => {
+    const stored = typeof window !== 'undefined' ? localStorage.getItem('kaizen_streak') : null;
+    setStreak(stored ? Number(stored) : 0);
+  }, []);
 
   const handleGenerate = () => {
     const req = buildLessonRequest({
@@ -26,6 +31,9 @@ export default function ChatHomeShell({ initialThreadId }: Props) {
     });
     console.log('LessonRequest', req);
     // TODO: fetch('/api/lessons/generate', { method: 'POST', body: JSON.stringify(req) })
+    const next = streak + 1;
+    setStreak(next);
+    try { localStorage.setItem('kaizen_streak', String(next)); } catch {}
   };
 
   const threadExists = activeThreadId ? threads.some(t => t.id === activeThreadId) : true;
@@ -48,8 +56,9 @@ export default function ChatHomeShell({ initialThreadId }: Props) {
         )}
       </AnimatePresence>
       <div className="flex-1 flex flex-col min-h-0">
-        <div className="flex justify-start p-2 border-b border-black/10">
-          <Button onClick={handleGenerate} className="text-xs px-2 py-1">Home</Button>
+        <div className="flex justify-between p-2 border-b border-black/10">
+          <div className="text-xs">Streak: {streak}</div>
+          <Button onClick={handleGenerate} className="text-xs px-2 py-1">Random Lesson</Button>
         </div>
         <ChatPane onOpenSidebar={() => setDrawer(true)} />
       </div>

--- a/src/components/kaizen/constants.ts
+++ b/src/components/kaizen/constants.ts
@@ -1,0 +1,1 @@
+export const KAIZEN_PAGE_CLASS = "min-h-screen flex flex-col bg-white text-black font-sans";

--- a/src/ui/components/kaizen/Header.tsx
+++ b/src/ui/components/kaizen/Header.tsx
@@ -7,12 +7,26 @@ interface NavItem {
   label: string;
 }
 
-interface HeaderProps {
-  items: NavItem[];
-  onStart: () => void;
+interface LinkItem {
+  href: string;
+  label: string;
 }
 
-export default function Header({ items = [], onStart }: HeaderProps) {
+interface HeaderProps {
+  items?: NavItem[];
+  links?: LinkItem[];
+  onStart?: () => void;
+  showStart?: boolean;
+  homeHref?: string;
+}
+
+export default function Header({
+  items = [],
+  links = [],
+  onStart = () => {},
+  showStart = true,
+  homeHref = '#',
+}: HeaderProps) {
   const [active, setActive] = useState(items[0]?.id);
   const [open, setOpen] = useState(false);
 
@@ -43,7 +57,7 @@ export default function Header({ items = [], onStart }: HeaderProps) {
   return (
     <header className="fixed top-0 z-50 w-full bg-white backdrop-blur-xl">
       <nav className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
-        <a href="#" className="text-lg font-semibold text-black">Kaizen 改善</a>
+        <a href={homeHref} className="text-lg font-semibold text-black">Kaizen 改善</a>
         <button
           className="sm:hidden"
           onClick={() => setOpen((v) => !v)}
@@ -66,15 +80,27 @@ export default function Header({ items = [], onStart }: HeaderProps) {
               </button>
             </li>
           ))}
+          {links.map((link) => (
+            <li key={link.href}>
+              <a
+                href={link.href}
+                className="text-sm font-medium text-black hover:text-green-400"
+              >
+                {link.label}
+              </a>
+            </li>
+          ))}
         </ul>
-        <div className="hidden sm:block">
-          <button
-            onClick={onStart}
-            className="rounded-md bg-green-500/20 px-4 py-2 text-sm text-black text-center shadow hover:bg-green-500/30"
-          >
-            Start
-          </button>
-        </div>
+        {showStart && (
+          <div className="hidden sm:block">
+            <button
+              onClick={onStart}
+              className="rounded-md bg-green-500/20 px-4 py-2 text-sm text-black text-center shadow hover:bg-green-500/30"
+            >
+              Start
+            </button>
+          </div>
+        )}
       </nav>
     </header>
   );


### PR DESCRIPTION
## Summary
- reuse introduction header across kaizen pages and add navigation links
- share page styling via constant and align chat route styling
- track streaks and expose random lesson trigger

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aac4df0f0c832ea0fe803b1d7e0d81